### PR TITLE
fix: Add missing healthcheck dependency (curl)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,13 +27,19 @@ ENV/
 *.swo
 
 # Project specific
-examples/
+*examples/*.wav
+*examples/*.pcm
+*examples/*.mp3
+*examples/*.flac
+*examples/*.acc
+*examples/*.ogg
+
 Kokoro-82M/
-ui/
+ui/data
 tests/
 *.md
 *.txt
-!requirements.txt
+requirements.txt
 
 # Docker
 Dockerfile*

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     espeak-ng \
     git \
     libsndfile1 \
+    curl \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     espeak-ng \
     git \
     libsndfile1 \
+    curl \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docker-compose.cpu.yml
+++ b/docker-compose.cpu.yml
@@ -26,11 +26,12 @@ services:
       start_period: 1s
 
   kokoro-tts:
-    image: ghcr.io/remsky/kokoro-fastapi-cpu:latest
+
+    # image: ghcr.io/remsky/kokoro-fastapi-cpu:latest
     # Uncomment below (and comment out above) to build from source instead of using the released image
-    # build:
-      # context: .
-      # dockerfile: Dockerfile.cpu
+    build:
+      context: .
+      dockerfile: Dockerfile.cpu
     volumes:
       - ./api/src:/app/api/src
       - ./Kokoro-82M:/app/Kokoro-82M
@@ -46,9 +47,16 @@ services:
       - ONNX_MEMORY_PATTERN=true
       - ONNX_ARENA_EXTEND_STRATEGY=kNextPowerOfTwo
       
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8880/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 30s
     depends_on:
       model-fetcher:
         condition: service_healthy
+
 
   # Gradio UI service [Comment out everything below if you don't need it]
   gradio-ui:
@@ -64,3 +72,6 @@ services:
     environment:
       - GRADIO_WATCH=True  # Enable hot reloading
       - PYTHONUNBUFFERED=1  # Ensure Python output is not buffered
+    depends_on:
+      kokoro-tts:
+        condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,10 +32,10 @@ services:
       start_period: 1s
 
   kokoro-tts:
-    image: ghcr.io/remsky/kokoro-fastapi-gpu:latest
+    # image: ghcr.io/remsky/kokoro-fastapi-gpu:latest
     # Uncomment below (and comment out above) to build from source instead of using the released image
-    # build:
-      # context: .
+    build:
+      context: .
     volumes:
       - ./api/src:/app/api/src
       - ./Kokoro-82M:/app/Kokoro-82M
@@ -51,7 +51,7 @@ services:
               count: 1
               capabilities: [gpu]
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8880/v1/audio/voices"]
+      test: ["CMD", "curl", "-f", "http://localhost:8880/health"]
       interval: 10s
       timeout: 5s
       retries: 30


### PR DESCRIPTION
Currently healthchecks fail for `kokoro-tts` container since curl is not installed.