### PR TITLE
Update README.md with new local endpoint usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,13 +56,14 @@ The service can be accessed through either the API endpoints or the Gradio web i
         api_key="not-needed"
         )
 
-    response = client.audio.speech.create(
+    with client.audio.speech.with_streaming_response.create(
         model="kokoro", 
         voice="af_sky+af_bella", #single or multiple voicepack combo
         input="Hello world!",
         response_format="mp3"
-    )
-    response.stream_to_file("output.mp3")
+    ) as response:
+        response.stream_to_file("output.mp3")
+    
     ```
 
     or visit http://localhost:7860


### PR DESCRIPTION
The old method will result in a deprecation warning, this is the recommended method via openAI.

```python
@deprecated(
   "Due to a bug, this method doesn't actually stream the response content, `.with_streaming_response.method()` should be used instead"
)
def stream_to_file(
...
```