### PR TITLE
Try to add AAC audio format w/ updated test

### DIFF
--- a/api/tests/test_audio_service.py
+++ b/api/tests/test_audio_service.py
@@ -58,14 +58,14 @@ def test_convert_to_flac(sample_audio):
     assert len(result) > 0
 
 
-def test_convert_to_aac_raises_error(sample_audio):
-    """Test that converting to AAC raises an error"""
+def test_convert_to_aac(sample_audio):
+    """Test converting to AAC format"""
     audio_data, sample_rate = sample_audio
-    with pytest.raises(
-        ValueError,
-        match="Failed to convert audio to aac: Format aac not currently supported. Supported formats are: wav, mp3, opus, flac, pcm.",
-    ):
-        AudioService.convert_audio(audio_data, sample_rate, "aac")
+    result = AudioService.convert_audio(audio_data, sample_rate, "aac")
+    assert isinstance(result, bytes)
+    assert len(result) > 0
+    # AAC files typically start with an ADTS header
+    assert result.startswith(b'\xff\xf1') or result.startswith(b'\xff\xf9')
 
 
 def test_convert_to_pcm(sample_audio):

--- a/docker/cpu/Dockerfile
+++ b/docker/cpu/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     libsndfile1 \
     curl \
+    ffmpeg \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docker/gpu/Dockerfile
+++ b/docker/gpu/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     libsndfile1 \
     curl \
+    ffmpeg \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docker/shared/pyproject.toml
+++ b/docker/shared/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "munch==4.0.0",
     "tiktoken==0.8.0",
     "loguru==0.7.3",
+    "pydub>=0.25.1",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "openai>=1.59.6",
     "ebooklib>=0.18",
     "html2text>=2024.2.26",
+    "pydub>=0.25.1",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
I downloaded the macOS app `Speech Control`, which is a tts document reader which supports drop-in OpenAI endpoints.

It uses AAC formatting, so I have tried to implement this and contribute with a PR, let me know if I did everything correctly? I can confirm that it works in a Docker instance on M4 pro.

It uses `pydub` to convert the normalized to AAC, which I added to `docker/shared/pyproject.toml` and `pyproject.toml`  and `ffmpeg` is a requirement of pydub, which I added to both the Dockerfiles. 

I also ran the test suite in the docker container and it seemed to pass all tests.