### PR TITLE
fixed some problems in the build system and model download system

### DIFF
--- a/api/src/core/paths.py
+++ b/api/src/core/paths.py
@@ -41,7 +41,7 @@ async def _find_file(
             if filter_fn is None or filter_fn(full_path):
                 return full_path
                 
-    raise RuntimeError(f"File not found: {filename} in paths: {search_paths}")
+    raise FileNotFoundError(f"File not found: {filename} in paths: {search_paths}")
 
 
 async def _scan_directories(

--- a/api/src/inference/kokoro_v1.py
+++ b/api/src/inference/kokoro_v1.py
@@ -60,7 +60,8 @@ class KokoroV1(BaseModelBackend):
                 model=self._model,  # Pass our model directly
                 device=self._device  # Match our device setting
             )
-            
+        except FileNotFoundError as e:
+            raise e
         except Exception as e:
             raise RuntimeError(f"Failed to load Kokoro model: {e}")
 

--- a/api/src/inference/model_manager.py
+++ b/api/src/inference/model_manager.py
@@ -81,7 +81,17 @@ class ModelManager:
             logger.info(f"Warmup completed in {ms}ms")
             
             return self._device, "kokoro_v1", len(voices)
-            
+        except FileNotFoundError as e:
+            logger.error("""
+Model files not found! You need to download the Kokoro V1 model:
+
+1. Download model using the script:
+   python docker/scripts/download_model.py --output api/src/models/v1_0
+
+2. Or set environment variable in docker-compose:
+   DOWNLOAD_MODEL=true
+""")
+            exit(0)
         except Exception as e:
             raise RuntimeError(f"Warmup failed: {e}")
 
@@ -112,6 +122,8 @@ class ModelManager:
             
         try:
             await self._backend.load_model(path)
+        except FileNotFoundError as e:
+            raise e
         except Exception as e:
             raise RuntimeError(f"Failed to load model: {e}")
 

--- a/api/src/main.py
+++ b/api/src/main.py
@@ -62,18 +62,7 @@ async def lifespan(app: FastAPI):
         # Initialize model with warmup and get status
         device, model, voicepack_count = await model_manager\
             .initialize_with_warmup(voice_manager)
-    
-    except FileNotFoundError:
-        logger.error("""
-Model files not found! You need to download the Kokoro V1 model:
 
-1. Download model using the script:
-   python docker/scripts/download_model.py --version v1_0 --output api/src/models/v1_0
-
-2. Or set environment variable in docker-compose:
-   DOWNLOAD_MODEL=true
-""")
-        raise
     except Exception as e:
         logger.error(f"Failed to initialize model: {e}")
         raise

--- a/api/tests/test_paths.py
+++ b/api/tests/test_paths.py
@@ -23,7 +23,7 @@ async def test_find_file_not_exists():
     """Test finding non-existent file."""
     with patch('aiofiles.os.path.exists') as mock_exists:
         mock_exists.return_value = False
-        with pytest.raises(RuntimeError, match="File not found"):
+        with pytest.raises(FileNotFoundError, match="File not found"):
             await _find_file("test.txt", ["/test/path"])
 
 @pytest.mark.asyncio

--- a/docker/cpu/Dockerfile
+++ b/docker/cpu/Dockerfile
@@ -37,7 +37,8 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # Copy project files including models
 COPY --chown=appuser:appuser api ./api
 COPY --chown=appuser:appuser web ./web
-COPY --chown=appuser:appuser docker/scripts/download_model.* ./
+COPY --chown=appuser:appuser docker/scripts/ ./
+RUN chmod +x ./entrypoint.sh
 
 # Set environment variables
 ENV PYTHONUNBUFFERED=1 \
@@ -54,5 +55,6 @@ RUN if [ "$DOWNLOAD_MODEL" = "true" ]; then \
     python download_model.py --output api/src/models/v1_0; \
     fi
 
-# Run FastAPI server
-CMD ["uv", "run", "python", "-m", "uvicorn", "api.src.main:app", "--host", "0.0.0.0", "--port", "8880", "--log-level", "debug"]
+ENV DEVICE="cpu"
+# Run FastAPI server through entrypoint.sh
+CMD ["./entrypoint.sh"]

--- a/docker/gpu/Dockerfile
+++ b/docker/gpu/Dockerfile
@@ -38,7 +38,8 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # Copy project files including models and sync again
 COPY --chown=appuser:appuser api ./api
 COPY --chown=appuser:appuser web ./web
-COPY --chown=appuser:appuser docker/scripts/download_model.* ./
+COPY --chown=appuser:appuser docker/scripts/ ./
+RUN chmod +x ./entrypoint.sh
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --extra gpu
 
@@ -57,5 +58,6 @@ RUN if [ "$DOWNLOAD_MODEL" = "true" ]; then \
     python download_model.py --output api/src/models/v1_0; \
     fi
 
-# Run FastAPI server
-CMD ["uv", "run", "python", "-m", "uvicorn", "api.src.main:app", "--host", "0.0.0.0", "--port", "8880", "--log-level", "debug"]
+ENV DEVICE="gpu"
+# Run FastAPI server through entrypoint.sh
+CMD ["./entrypoint.sh"]

--- a/docker/scripts/download_model.py
+++ b/docker/scripts/download_model.py
@@ -3,7 +3,6 @@
 
 import json
 import os
-import shutil
 from pathlib import Path
 from urllib.request import urlretrieve
 

--- a/docker/scripts/entrypoint.sh
+++ b/docker/scripts/entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 if [ "$DOWNLOAD_MODEL" = "true" ]; then
-    python docker/scripts/download_model.py --output api/src/models/v1_0
+    python download_model.py --output api/src/models/v1_0
 fi
 
-exec uv run python -m uvicorn api.src.main:app --host 0.0.0.0 --port 8880 --log-level debug
+exec uv run --extra $DEVICE python -m uvicorn api.src.main:app --host 0.0.0.0 --port 8880 --log-level debug


### PR DESCRIPTION
Build system:
* When running the docker compose CPU image it would download Nvidia GPU packages everytime at startup (It did not cache but I just prevented that anyway)

Download system:
* Setting env DOWNLOAD_MODEL=true would not download the model when using the default docker compose
* The help message telling the user how to download the model would not actually show
* The help message gave an invalid command arg (--version)