### PR TITLE
fix skipping over some words

### DIFF
--- a/api/src/inference/kokoro_v1.py
+++ b/api/src/inference/kokoro_v1.py
@@ -12,7 +12,9 @@ from ..core import paths
 from ..core.config import settings
 from ..core.model_config import model_config
 from .base import BaseModelBackend
+from misaki import espeak
 
+fallback=espeak.EspeakFallback(british=False)
 
 class KokoroV1(BaseModelBackend):
     """Kokoro backend with controlled resource management."""


### PR DESCRIPTION
related issue:
[skipping over some words](https://huggingface.co/hexgrad/Kokoro-82M/discussions/120)
and
[here](https://github.com/hexgrad/kokoro/issues/24#issuecomment-2652967388)

also should comment out `EspeakWrapper.set_data_path()` and set the correct library path for `EspeakWrapper.set_library()` in misaki `__init__`