### PR TITLE
Disable --reload on unicorn/fastapi to avoid pegging a CPU core

### DIFF
--- a/start-cpu.sh
+++ b/start-cpu.sh
@@ -14,4 +14,4 @@ export WEB_PLAYER_PATH=$PROJECT_ROOT/web
 # Run FastAPI with CPU extras using uv run
 # Note: espeak may still require manual installation,
 uv pip install -e ".[cpu]"
-uv run uvicorn api.src.main:app --reload --host 0.0.0.0 --port 8880
+uv run uvicorn api.src.main:app --host 0.0.0.0 --port 8880

--- a/start-gpu.sh
+++ b/start-gpu.sh
@@ -13,4 +13,4 @@ export WEB_PLAYER_PATH=$PROJECT_ROOT/web
 
 # Run FastAPI with GPU extras using uv run
 uv pip install -e ".[gpu]"
-uv run uvicorn api.src.main:app --reload --host 0.0.0.0 --port 8880
+uv run uvicorn api.src.main:app --host 0.0.0.0 --port 8880


### PR DESCRIPTION
The `--reload` causes FastAPI to hog a cpu core at ~100% just to watch for changes. I expect most people are not looking to hot-reload changes to the server in normal use.

See: https://github.com/fastapi/fastapi/discussions/8126