### PR TITLE
converted CRLF ending lines to LF ones in api/src/structures/custom_responses.py

### DIFF
--- a/api/src/structures/custom_responses.py
+++ b/api/src/structures/custom_responses.py
@@ -1,7 +1,7 @@
-from collections.abc import AsyncIterable, Iterable
-
 import json
 import typing
+from collections.abc import AsyncIterable, Iterable
+
 from pydantic import BaseModel
 from starlette.background import BackgroundTask
 from starlette.concurrency import iterate_in_threadpool

--- a/docker/gpu/docker-compose.yml
+++ b/docker/gpu/docker-compose.yml
@@ -1,6 +1,9 @@
 name: kokoro-tts-gpu
 services:
   kokoro-tts:
+    user: "${UID}:${GID}"
+    group_add:
+      - "video"
     # image: ghcr.io/remsky/kokoro-fastapi-gpu:v0.2.0
     build:
       context: ../..

--- a/docker/gpu/docker-compose.yml
+++ b/docker/gpu/docker-compose.yml
@@ -1,9 +1,6 @@
 name: kokoro-tts-gpu
 services:
   kokoro-tts:
-    user: "${UID}:${GID}"
-    group_add:
-      - "video"
     # image: ghcr.io/remsky/kokoro-fastapi-gpu:v0.2.0
     build:
       context: ../..


### PR DESCRIPTION
I had trouble with custom_response.py (which I didn't touch) where windows style ending lines CRLF were making my IDE buggy, so I ended up converting it to Linux style LF.