### PR TITLE
docs: added a note for Apple Silicon users regarding GPU build

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ docker run --gpus all -p 8880:8880 ghcr.io/remsky/kokoro-fastapi-gpu:v0.2.2  #NV
         # or cd docker/cpu  # For CPU support
         docker compose up --build
 
+        # *Note for Apple Silicon (M1/M2) users:
+        # The current GPU build relies on CUDA, which is not supported on Apple Silicon.  
+        # If you are on an M1/M2/M3 Mac, please use the `docker/cpu` setup.  
+        # MPS (Apple’s GPU acceleration) support is planned but not yet available.
+
         # Models will auto-download, but if needed you can manually download:
         python docker/scripts/download_model.py --output api/src/models/v1_0
 


### PR DESCRIPTION
Clarified in the Docker documentation that the GPU build is CUDA-only and not supported on Apple Silicon (M1/M2/M3) to avoid confusion. Advised using the CPU build (docker/cpu) and noted that MPS support is still to come.