### PR TITLE
use local js file instead of the unpkg cdn

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -16,7 +16,7 @@
     <link rel="stylesheet" href="styles/responsive.css">
     <link rel="stylesheet" href="styles/badges.css">
     <link rel="stylesheet" href="styles/controls.css">
-    <script src="https://unpkg.com/siriwave/dist/siriwave.umd.min.js"></script>
+    <script src="./siriwave.js"></script>
     <script async defer src="https://buttons.github.io/buttons.js"></script>
 </head>
 <body>


### PR DESCRIPTION
this fixes #243 

unpg.com was down, which broke the ui. 
I guess for stability dependencies should be local or at least pinned to a version.

Also I think the placement of the js file in `web` directory and not even in `web/src` is unfortunate.
This should probably be cleaned up in a way but this is the quick and diry way to get it working as of now.