### PR TITLE
Fix mp3 encoding

### DIFF
--- a/start-gpu_mac.sh
+++ b/start-gpu_mac.sh
@@ -3,22 +3,7 @@
 # Get project root directory
 PROJECT_ROOT=$(pwd)
 
-# Create mps-specific venv directory
-VENV_DIR="$PROJECT_ROOT/.venv-mps"
-if [ ! -d "$VENV_DIR" ]; then
-    echo "Creating MPS-specific virtual environment..."
-    python3 -m venv "$VENV_DIR"
-fi
-
 # Set other environment variables
-export USE_GPU=true
-export USE_ONNX=false
-export PYTHONPATH=$PROJECT_ROOT:$PROJECT_ROOT/api
-export MODEL_DIR=src/models
-export VOICES_DIR=src/voices/v1_0
-export WEB_PLAYER_PATH=$PROJECT_ROOT/web
-
-# Set environment variables
 export USE_GPU=true
 export USE_ONNX=false
 export PYTHONPATH=$PROJECT_ROOT:$PROJECT_ROOT/api
@@ -32,4 +17,5 @@ export PYTORCH_ENABLE_MPS_FALLBACK=1
 
 # Run FastAPI with GPU extras using uv run
 uv pip install -e .
+uv run --no-sync python docker/scripts/download_model.py --output api/src/models/v1_0
 uv run --no-sync uvicorn api.src.main:app --host 0.0.0.0 --port 8880


### PR DESCRIPTION
I found that the MP3 created by the API aren't valid MP3 files, and not playable unless re-encoded with ffmpeg. I think the reason is because MP3 files are typically not streamable or chunked.

This pull request collects all audio chunks in memory and create a full audio file for MP3 instead of the existing stream approach. The output MP3s are now playable without conversion beforehand.