### PR TITLE
Add a volume multiplier setting

### DIFF
--- a/api/src/core/config.py
+++ b/api/src/core/config.py
@@ -31,6 +31,7 @@ class Settings(BaseSettings):
 
     # Audio Settings
     sample_rate: int = 24000
+    volume_multiplier: float = 1.0
     # Text Processing Settings
     target_min_tokens: int = 175  # Target minimum tokens per chunk
     target_max_tokens: int = 250  # Target maximum tokens per chunk

--- a/api/src/inference/model_manager.py
+++ b/api/src/inference/model_manager.py
@@ -141,6 +141,8 @@ Model files not found! You need to download the Kokoro V1 model:
 
         try:
             async for chunk in self._backend.generate(*args, **kwargs):
+                if settings.volume_multiplier != 1.0:
+                    chunk.audio *= settings.volume_multiplier
                 yield chunk
         except Exception as e:
             raise RuntimeError(f"Generation failed: {e}")


### PR DESCRIPTION
Allow configuring output volume via multiplier applied to np array of audio chunk.

Defaults to 1.0 which is no-op.

Fixes #110