### PR TITLE
Update PyTorch to 2.7.1+cu128 for RTX 50 Series GPU Support

### DIFF
--- a/docker/gpu/Dockerfile
+++ b/docker/gpu/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM nvidia/cuda:12.8.0-cudnn-runtime-ubuntu24.04
+FROM --platform=$BUILDPLATFORM nvidia/cuda:12.8.1-cudnn-runtime-ubuntu24.04
 # Set non-interactive frontend
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,10 +44,10 @@ dependencies = [
 
 [project.optional-dependencies]
 gpu = [
-    "torch==2.6.0+cu124",
+    "torch==2.7.1+cu128",
 ]
 cpu = [
-    "torch==2.6.0",
+    "torch==2.7.1",
 ]
 test = [
     "pytest==8.3.5",
@@ -79,7 +79,7 @@ explicit = true
 
 [[tool.uv.index]]
 name = "pytorch-cuda"
-url = "https://download.pytorch.org/whl/cu124"
+url = "https://download.pytorch.org/whl/cu128"
 explicit = true
 
 [build-system]


### PR DESCRIPTION
### Motivation
This PR updates PyTorch from version 2.6.0+cu124 to 2.7.1+cu128 to support newer GPU architectures, specifically the RTX 50 series cards (RTX 5070, etc.). The current PyTorch version lacks support for these latest GPUs, preventing users with newer hardware from using the application.

### Changes
- **pyproject.toml**: Updated PyTorch dependency from `torch==2.6.0+cu124` to `torch==2.7.1+cu128`
- **Dockerfile**: Updated CUDA base image from version 12.8.0 to 12.8.1 to match the PyTorch CUDA requirements

### Testing
- ✅ Tested containerized deployment - works correctly
- ✅ Tested non-Docker deployment - works correctly  
- ✅ Verified GPU functionality - RTX 5070 now supported
- ✅ Verified CPU fallback - continues to work as expected

### Related Issues
Fixes #344 - Request for different CUDA version containers for RTX 5000 series support
Fixes #320 - Compatibility issue with RTX 50 Series cards due to outdated PyTorch version

### Benefits
- Enables support for RTX 50 series GPUs out of the box
- Reduces the need for users to manually rebuild containers
- Maintains backward compatibility with existing GPU configurations
- Improves environmental impact by providing pre-built containers instead of requiring individual rebuilds

This update ensures that users with the latest GPU hardware can use the application without manual modifications while maintaining compatibility with existing setups.