### PR TITLE
Smaller docker image

### DIFF
--- a/docker/cpu/Dockerfile
+++ b/docker/cpu/Dockerfile
@@ -1,26 +1,17 @@
 FROM python:3.10-slim 
 
 # Install dependencies and check espeak location
-RUN apt-get update && apt-get install -y \
-    espeak-ng \
-    espeak-ng-data \
-    git \
-    libsndfile1 \
-    curl \
-    ffmpeg \
-    g++ \
-&& apt-get clean \
-&& rm -rf /var/lib/apt/lists/* \
-&& mkdir -p /usr/share/espeak-ng-data \
-&& ln -s /usr/lib/*/espeak-ng-data/* /usr/share/espeak-ng-data/
-
-# Install UV using the installer script
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
+# Rust is required to build sudachipy and pyopenjtalk-plus
+RUN apt-get update -y &&  \
+    apt-get install -y espeak-ng espeak-ng-data git libsndfile1 curl ffmpeg g++ && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* && \
+    mkdir -p /usr/share/espeak-ng-data && \
+    ln -s /usr/lib/*/espeak-ng-data/* /usr/share/espeak-ng-data/ && \
+    curl -LsSf https://astral.sh/uv/install.sh | sh && \
     mv /root/.local/bin/uv /usr/local/bin/ && \
-    mv /root/.local/bin/uvx /usr/local/bin/
-
-# Create non-root user and set up directories and permissions
-RUN useradd -m -u 1000 appuser && \
+    mv /root/.local/bin/uvx /usr/local/bin/ && \
+    curl https://sh.rustup.rs -sSf | sh -s -- -y && \
+    useradd -m -u 1000 appuser && \
     mkdir -p /app/api/src/models/v1_0 && \
     chown -R appuser:appuser /app
 
@@ -30,14 +21,9 @@ WORKDIR /app
 # Copy dependency files
 COPY --chown=appuser:appuser pyproject.toml ./pyproject.toml
 
-# Install Rust (required to build sudachipy and pyopenjtalk-plus)
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
-ENV PATH="/home/appuser/.cargo/bin:$PATH"
-
-# Install dependencies
-RUN --mount=type=cache,target=/root/.cache/uv \
-    uv venv --python 3.10 && \
-    uv sync --extra cpu
+# Install dependencies with CPU extras
+RUN uv venv --python 3.10 && \
+    uv sync --extra cpu --no-cache
 
 # Copy project files including models
 COPY --chown=appuser:appuser api ./api
@@ -46,14 +32,15 @@ COPY --chown=appuser:appuser docker/scripts/ ./
 RUN chmod +x ./entrypoint.sh
 
 # Set environment variables
-ENV PYTHONUNBUFFERED=1 \
+ENV PATH="/home/appuser/.cargo/bin:/app/.venv/bin:$PATH" \
+    PYTHONUNBUFFERED=1 \
     PYTHONPATH=/app:/app/api \
-    PATH="/app/.venv/bin:$PATH" \
     UV_LINK_MODE=copy \
     USE_GPU=false \
     PHONEMIZER_ESPEAK_PATH=/usr/bin \
     PHONEMIZER_ESPEAK_DATA=/usr/share/espeak-ng-data \
-    ESPEAK_DATA_PATH=/usr/share/espeak-ng-data
+    ESPEAK_DATA_PATH=/usr/share/espeak-ng-data \
+    DEVICE="cpu"
 
 ENV DOWNLOAD_MODEL=true
 # Download model if enabled
@@ -61,6 +48,5 @@ RUN if [ "$DOWNLOAD_MODEL" = "true" ]; then \
     python download_model.py --output api/src/models/v1_0; \
     fi
 
-ENV DEVICE="cpu"
 # Run FastAPI server through entrypoint.sh
 CMD ["./entrypoint.sh"]

--- a/docker/gpu/Dockerfile
+++ b/docker/gpu/Dockerfile
@@ -1,29 +1,15 @@
-FROM --platform=$BUILDPLATFORM nvidia/cuda:12.8.1-cudnn-runtime-ubuntu24.04
-# Set non-interactive frontend
-ENV DEBIAN_FRONTEND=noninteractive
+FROM --platform=$BUILDPLATFORM nvidia/cuda:12.8.1-base-ubuntu24.04
 
 # Install Python and other dependencies
-RUN apt-get update && apt-get install -y \
-    python3.10 \
-    python3-venv \
-    espeak-ng \
-    espeak-ng-data \
-    git \
-    libsndfile1 \
-    curl \
-    ffmpeg \
-    g++ \
- && apt-get clean && rm -rf /var/lib/apt/lists/* \
- && mkdir -p /usr/share/espeak-ng-data \
- && ln -s /usr/lib/*/espeak-ng-data/* /usr/share/espeak-ng-data/
-
-# Install UV using the installer script
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
+RUN apt-get update -y &&  \
+    apt-get install -y python3.10 python3-venv espeak-ng espeak-ng-data git libsndfile1 curl ffmpeg g++ &&  \
+    apt-get clean && rm -rf /var/lib/apt/lists/* && \
+    mkdir -p /usr/share/espeak-ng-data &&  \
+    ln -s /usr/lib/*/espeak-ng-data/* /usr/share/espeak-ng-data/ && \
+    curl -LsSf https://astral.sh/uv/install.sh | sh && \
     mv /root/.local/bin/uv /usr/local/bin/ && \
-    mv /root/.local/bin/uvx /usr/local/bin/ 
-
-# Create non-root user and set up directories and permissions
-RUN useradd -m -u 1001 appuser && \
+    mv /root/.local/bin/uvx /usr/local/bin/ && \
+    useradd -m -u 1001 appuser && \
     mkdir -p /app/api/src/models/v1_0 && \
     chown -R appuser:appuser /app
     
@@ -33,14 +19,9 @@ WORKDIR /app
 # Copy dependency files
 COPY --chown=appuser:appuser pyproject.toml ./pyproject.toml
 
-ENV PHONEMIZER_ESPEAK_PATH=/usr/bin \
-    PHONEMIZER_ESPEAK_DATA=/usr/share/espeak-ng-data \
-    ESPEAK_DATA_PATH=/usr/share/espeak-ng-data
-
-# Install dependencies with GPU extras (using cache mounts)
-RUN --mount=type=cache,target=/root/.cache/uv \
-    uv venv --python 3.10 && \
-    uv sync --extra gpu
+# Install dependencies with GPU extras
+RUN uv venv --python 3.10 && \
+    uv sync --extra gpu --no-cache
 
 # Copy project files including models
 COPY --chown=appuser:appuser api ./api
@@ -50,18 +31,21 @@ RUN chmod +x ./entrypoint.sh
 
 
 # Set all environment variables in one go
-ENV PYTHONUNBUFFERED=1 \
+ENV PATH="/app/.venv/bin:$PATH" \
+    PYTHONUNBUFFERED=1 \
     PYTHONPATH=/app:/app/api \
-    PATH="/app/.venv/bin:$PATH" \
     UV_LINK_MODE=copy \
-    USE_GPU=true 
-
+    USE_GPU=true \
+    PHONEMIZER_ESPEAK_PATH=/usr/bin \
+    PHONEMIZER_ESPEAK_DATA=/usr/share/espeak-ng-data \
+    ESPEAK_DATA_PATH=/usr/share/espeak-ng-data \
+    DEVICE="gpu"
+    
 ENV DOWNLOAD_MODEL=true
 # Download model if enabled
 RUN if [ "$DOWNLOAD_MODEL" = "true" ]; then \
     python download_model.py --output api/src/models/v1_0; \
     fi
 
-ENV DEVICE="gpu"
 # Run FastAPI server through entrypoint.sh
 CMD ["./entrypoint.sh"]


### PR DESCRIPTION
Smaller docker image:
- CPU image 5.6Gb -> 4.9Gb
- GPU image 14.8Gb -> 9.9Gb

Saved 4.2GBby using the cuda base image instead of cudnn-runtime. Saved 700MB by deleting the UV cache.

Improved the speed of rebuilding the image by merging the RUN commands into one.