### PR TITLE
Fix test_initial_state() test failure on apple silicon.

### DIFF
--- a/api/tests/test_kokoro_v1.py
+++ b/api/tests/test_kokoro_v1.py
@@ -19,7 +19,7 @@ def test_initial_state(kokoro_backend):
     assert kokoro_backend._model is None
     assert kokoro_backend._pipelines == {}  # Now using dict of pipelines
     # Device should be set based on settings
-    assert kokoro_backend.device in ["cuda", "cpu"]
+    assert kokoro_backend.device in ["cuda", "cpu", "mps"]
 
 
 @patch("torch.cuda.is_available", return_value=True)


### PR DESCRIPTION
Fix test failure on Apple Silicon.

```
(Kokoro-FastAPI) Macximum (upstream-master %=):~/scm/Kokoro-FastAPI$ uv run pytest
FAILED api/tests/test_kokoro_v1.py::test_initial_state - AssertionError: assert 'mps' in ['cuda', 'cpu']
======================================= 1 failed, 81 passed, 9 warnings in 1.56s =======================================
```