### PR TITLE
Fix(cpu/docker): install Rust for appuser, set PATH, and increase uv timeouts to stabilize build

### DIFF
--- a/docker/cpu/Dockerfile
+++ b/docker/cpu/Dockerfile
@@ -10,13 +10,20 @@ RUN apt-get update -y &&  \
     curl -LsSf https://astral.sh/uv/install.sh | sh && \
     mv /root/.local/bin/uv /usr/local/bin/ && \
     mv /root/.local/bin/uvx /usr/local/bin/ && \
-    curl https://sh.rustup.rs -sSf | sh -s -- -y && \
     useradd -m -u 1000 appuser && \
     mkdir -p /app/api/src/models/v1_0 && \
     chown -R appuser:appuser /app
 
 USER appuser
 WORKDIR /app
+
+# Install Rust for the non-root user so builds (e.g., sudachipy) succeed
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+
+# Ensure Cargo and the Python venv are on PATH; extend HTTP timeouts for uv
+ENV PATH="/home/appuser/.cargo/bin:/app/.venv/bin:$PATH" \
+    UV_HTTP_TIMEOUT=120 \
+    UV_HTTP_RETRIES=3
 
 # Copy dependency files
 COPY --chown=appuser:appuser pyproject.toml ./pyproject.toml
@@ -32,8 +39,7 @@ COPY --chown=appuser:appuser docker/scripts/ ./
 RUN chmod +x ./entrypoint.sh
 
 # Set environment variables
-ENV PATH="/home/appuser/.cargo/bin:/app/.venv/bin:$PATH" \
-    PYTHONUNBUFFERED=1 \
+ENV PYTHONUNBUFFERED=1 \
     PYTHONPATH=/app:/app/api \
     UV_LINK_MODE=copy \
     USE_GPU=false \


### PR DESCRIPTION
## Summary
This PR fixes intermittent CPU image build failures by ensuring Rust is available to the non-root user during dependency installation and by increasing network timeouts for large wheels. It stabilizes `uv sync` on Apple Silicon and similar arm64 environments.

## What changed
- Dockerfile
  - Install Rust via rustup as the non-root `appuser` (so Rust is on PATH during `uv sync`).
  - Export PATH to include `/home/appuser/.cargo/bin` and `/app/.venv/bin` before dependency installation.
  - Add `UV_HTTP_TIMEOUT=120` and `UV_HTTP_RETRIES=3` to reduce transient network timeouts when fetching large wheels (e.g., numpy, torch).

No runtime behavior change; only build reliability improvements.

## Why
- `sudachipy` (pulled via `pyopenjtalk-plus` → `misaki[ja]`) requires a Rust compiler to build on arm64. When `uv sync` runs under `appuser`, Rust wasn’t available on PATH, causing:
  - error: can’t find Rust compiler
- Large wheels occasionally failed with network timeouts during extraction. Increasing uv HTTP timeouts and retries mitigates this.

## How I tested
- Built locally on macOS (Apple Silicon):
  - `docker compose up --build` in `docker/cpu`
  - Image built successfully; `uv sync` completed without Rust or numpy timeouts.
- Container started, downloaded model, warmed up, and served:
  - Web UI: http://localhost:8880/web/
  - OpenAI-compatible API: http://localhost:8880/v1
  - Verified logs show model warmup and server ready.

## Risk/impact
- Low. Changes are limited to the CPU Dockerfile build steps and environment variables.
- GPU paths/images are unaffected.

## Notes for reviewers
- Installing Rust as `appuser` is necessary because `uv sync` runs as that user; installing only as root leaves Rust off PATH for `appuser`.
- Timeout values are conservative and only affect build-time network operations (via uv).

## Checklist
- [x] CPU image builds reliably on arm64 (macOS) with `docker compose up --build`.
- [x] Container starts and serves /web and /v1 endpoints.
- [x] No breaking changes to runtime environment or API.

## Related
- Fixes build errors like “can’t find Rust compiler” during `sudachipy` build.
- Mitigates uv network timeouts for large wheels.