### PR TITLE
fix: Add reverse proxy support for web-ui

### DIFF
--- a/api/src/routers/web_player.py
+++ b/api/src/routers/web_player.py
@@ -1,5 +1,7 @@
 """Web player router with async file serving."""
 
+import os
+
 from fastapi import APIRouter, HTTPException
 from fastapi.responses import Response
 from loguru import logger
@@ -11,6 +13,20 @@ router = APIRouter(
     tags=["Web Player"],
     responses={404: {"description": "Not found"}},
 )
+
+
+@router.get("/config")
+async def get_web_config():
+    """Get web player configuration including UVICORN_ROOT_PATH."""
+    if not settings.enable_web_player:
+        raise HTTPException(status_code=404, detail="Web player is disabled")
+    
+    root_path = os.environ.get("UVICORN_ROOT_PATH", "")
+    
+    return {
+        "root_path": root_path,
+        "version": settings.api_version,
+    }
 
 
 @router.get("/{filename:path}")

--- a/web/src/config.js
+++ b/web/src/config.js
@@ -1,0 +1,89 @@
+/**
+ * Configuration for API endpoints
+ * Fetches root path from server to honor UVICORN_ROOT_PATH
+ */
+
+class Config {
+    constructor() {
+        this.rootPath = '';
+        this.initialized = false;
+        this.initPromise = this.initialize();
+    }
+    
+    async initialize() {
+        try {
+            // First detect root path from current URL
+            this.detectRootPath();
+            
+            // Then try to fetch server config to get the actual UVICORN_ROOT_PATH
+            // Use the detected root path to build the config URL
+            const configUrl = `${this.rootPath}/web/config`;
+            const response = await fetch(configUrl);
+            if (response.ok) {
+                const serverConfig = await response.json();
+                // Override with server's root path if provided
+                if (serverConfig.root_path !== undefined) {
+                    this.rootPath = serverConfig.root_path.replace(/\/$/, '');
+                    console.log('Config loaded from server. Root path:', this.rootPath);
+                }
+            } else {
+                console.log('Using detected root path:', this.rootPath);
+            }
+        } catch (error) {
+            console.log('Using detected root path (fetch failed):', this.rootPath, error.message);
+        }
+        this.initialized = true;
+    }
+    
+    detectRootPath() {
+        // Fallback: detect from current URL
+        const currentPath = window.location.pathname;
+        
+        // Extract root path by removing /web/ suffix if present
+        let rootPath = '';
+        if (currentPath.includes('/web/') || currentPath.endsWith('/web')) {
+            const webIndex = currentPath.indexOf('/web');
+            rootPath = currentPath.substring(0, webIndex);
+        } else if (currentPath.includes('/web')) {
+            rootPath = currentPath.split('/web')[0];
+        }
+        
+        this.rootPath = rootPath.replace(/\/$/, '');
+        console.log('Config initialized with detected rootPath:', this.rootPath);
+    }
+    
+    async ensureInitialized() {
+        if (!this.initialized) {
+            await this.initPromise;
+        }
+    }
+    
+    /**
+     * Get the full API URL for a given endpoint
+     * @param {string} endpoint - The endpoint path (e.g., '/v1/audio/speech')
+     * @returns {Promise<string>} The full URL with root path
+     */
+    async getApiUrl(endpoint) {
+        await this.ensureInitialized();
+        
+        // Ensure endpoint starts with /
+        if (!endpoint.startsWith('/')) {
+            endpoint = '/' + endpoint;
+        }
+        
+        return `${this.rootPath}${endpoint}`;
+    }
+    
+    /**
+     * Get the root path
+     * @returns {Promise<string>} The root path
+     */
+    async getRootPath() {
+        await this.ensureInitialized();
+        return this.rootPath;
+    }
+}
+
+// Export a singleton instance
+export const config = new Config();
+export default config;

--- a/web/src/services/AudioService.js
+++ b/web/src/services/AudioService.js
@@ -1,3 +1,5 @@
+import { config } from '../config.js';
+
 export class AudioService {
     constructor() {
         this.mediaSource = null;
@@ -33,7 +35,8 @@ export class AudioService {
             
             console.log('AudioService: Making API call...', { text, voice, speed });
             
-            const response = await fetch('/v1/audio/speech', {
+            const apiUrl = await config.getApiUrl('/v1/audio/speech');
+            const response = await fetch(apiUrl, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({
@@ -124,8 +127,8 @@ export class AudioService {
                     
                     const downloadPath = headers['x-download-path'];
                     if (downloadPath) {
-                        // Prepend /v1 since the router is mounted there
-                        this.serverDownloadPath = `/v1${downloadPath}`;
+                        // Use config to prepend root path and /v1
+                        this.serverDownloadPath = await config.getApiUrl(`/v1${downloadPath}`);
                         console.log('Download path received:', this.serverDownloadPath);
                     } else {
                         console.warn('No X-Download-Path header found. Available headers:',

--- a/web/src/services/VoiceService.js
+++ b/web/src/services/VoiceService.js
@@ -1,3 +1,5 @@
+import { config } from '../config.js';
+
 export class VoiceService {
     constructor() {
         this.availableVoices = [];
@@ -6,7 +8,8 @@ export class VoiceService {
 
     async loadVoices() {
         try {
-            const response = await fetch('/v1/audio/voices');
+            const apiUrl = await config.getApiUrl('/v1/audio/voices');
+            const response = await fetch(apiUrl);
             if (!response.ok) {
                 const error = await response.json();
                 throw new Error(error.detail?.message || 'Failed to load voices');


### PR DESCRIPTION
This addresses #397

With this change, kokoro can be used behind a reverse proxy by setting UVICORN_ROOT_PATH in the environment.

For example, with UVICORN_ROOT_PATH=/kokoro the ui can be accessed via /kokoro/web and the api is accessible under /kokoro/v1
