### PR TITLE
fix: downgrade PyTorch CUDA version from cu129 to cu126

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-gpu = ["torch==2.8.0+cu129"]
+gpu = ["torch==2.8.0+cu126"]
 cpu = ["torch==2.8.0"]
 test = [
     "pytest==8.3.5",
@@ -70,7 +70,7 @@ explicit = true
 
 [[tool.uv.index]]
 name = "pytorch-cuda"
-url = "https://download.pytorch.org/whl/cu129"
+url = "https://download.pytorch.org/whl/cu126"
 explicit = true
 
 [build-system]


### PR DESCRIPTION
This change might restore support for Maxwell and Pascal architectures.

- Updated GPU dependency from torch==2.8.0+cu129 to torch==2.8.0+cu126 in pyproject.toml
- Changed PyTorch CUDA index URL from https://download.pytorch.org/whl/cu129 to https://download.pytorch.org/whl/cu126
- This change ensures compatibility with CUDA 12.6 runtime while maintaining the same PyTorch version (2.8.0)