### PR TITLE
build: add cmake to fix pyopenjtalk dependency and sync CI deps with Docker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,13 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends \
           espeak-ng \
+          espeak-ng-data \
           git \
           libsndfile1 \
           curl \
-          ffmpeg
+          ffmpeg \
+          g++ \
+          cmake
     
     - name: Install uv
       uses: astral-sh/setup-uv@v5

--- a/docker/cpu/Dockerfile
+++ b/docker/cpu/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.10-slim
 # Install dependencies and check espeak location
 # Rust is required to build sudachipy and pyopenjtalk-plus
 RUN apt-get update -y &&  \
-    apt-get install -y espeak-ng espeak-ng-data git libsndfile1 curl ffmpeg g++ && \
+    apt-get install -y espeak-ng espeak-ng-data git libsndfile1 curl ffmpeg g++ cmake && \
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     mkdir -p /usr/share/espeak-ng-data && \
     ln -s /usr/lib/*/espeak-ng-data/* /usr/share/espeak-ng-data/ && \

--- a/docker/gpu/Dockerfile
+++ b/docker/gpu/Dockerfile
@@ -2,7 +2,7 @@ FROM --platform=$BUILDPLATFORM nvcr.io/nvidia/cuda:12.9.1-cudnn-devel-ubuntu24.0
 
 # Install Python and other dependencies
 RUN apt-get update -y &&  \
-    apt-get install -y python3.10 python3-venv espeak-ng espeak-ng-data git libsndfile1 curl ffmpeg g++ &&  \
+    apt-get install -y python3.10 python3-venv espeak-ng espeak-ng-data git libsndfile1 curl ffmpeg g++ cmake && \
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     mkdir -p /usr/share/espeak-ng-data &&  \
     ln -s /usr/lib/*/espeak-ng-data/* /usr/share/espeak-ng-data/ && \


### PR DESCRIPTION
Ensure that `cmake` is installed in both CPU and GPU Docker images, as well as in the GitHub Actions CI environment. Cmake is required to build `pyopenjtalk` because `kokoro-fastapi` depends on `misaki[ja]` which depends on `pyopenjtalk`. Additionally, sync CI dependency list.

Changes made:
- Added `cmake` to the apt-get install commands in:
  - `.github/workflows/ci.yml`
  - `docker/cpu/Dockerfile`
  - `docker/gpu/Dockerfile`
- Synchronize GitHub Actions CI workflow dependencies with Dockerfiles