### PR TITLE
Better sentence chunking algorithm to fix edge cases ("etc.", etc.)

### DIFF
--- a/api/tests/test_text_processor.py
+++ b/api/tests/test_text_processor.py
@@ -44,6 +44,28 @@ def test_get_sentence_info():
         assert count == len(tokens)
         assert count > 0
 
+def test_get_sentence_info_with_unicode_sentence_segmenting():
+    text = "".join([
+        "This, that, the other thing, etc. Another sentence... A, b, c, etc., and ",
+        "more. D, e, f, etc. and more. One, i. e. two. Three, i. e., four. Five, ",
+        "i.e. six. You have 4.2 messages. Property access: `a.b.c`.",
+    ])
+
+    info = get_sentence_info(text)
+    sentences = [s for (s, _, _) in info]
+
+    assert sentences == [
+        "This, that, the other thing, etc.",
+        "Another sentence...",
+        "A, b, c, etc., and more.",
+        "D, e, f, etc. and more.",
+        "One, i. e. two.",
+        "Three, i. e., four.",
+        "Five, i.e. six.",
+        "You have 4.2 messages.",
+        "Property access: `a.b.c`.",
+    ]
+
 @pytest.mark.asyncio
 async def test_smart_split_short_text():
     """Test smart splitting with text under max tokens."""

--- a/docs/requirements.in
+++ b/docs/requirements.in
@@ -18,7 +18,8 @@ soundfile==0.13.0
 
 # Text processing
 phonemizer==3.3.0
-regex==2024.11.6
+regex==2025.11.3
+unicode-segment==0.2.0
 
 # Utilities
 aiofiles==23.2.1  # Last version before Windows path handling changes

--- a/docs/requirements.in
+++ b/docs/requirements.in
@@ -19,7 +19,7 @@ soundfile==0.13.0
 # Text processing
 phonemizer==3.3.0
 regex==2025.11.3
-unicode-segment==0.2.0
+unicode-segment==0.4.2
 
 # Utilities
 aiofiles==23.2.1  # Last version before Windows path handling changes

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -169,12 +169,13 @@ referencing==0.35.1
     # via
     #   jsonschema
     #   jsonschema-specifications
-regex==2024.11.6
+regex==2025.11.3
     # via
     #   -r docs/requirements.in
     #   segments
     #   tiktoken
     #   transformers
+    #   unicode-segment
 requests==2.32.3
     # via
     #   -r docs/requirements.in
@@ -233,6 +234,8 @@ typing-extensions==4.12.2
     #   pydantic-core
     #   sqlalchemy
     #   uvicorn
+unicode-segment==0.2.0
+    # via -r docs/requirements.in
 uritemplate==4.1.1
     # via csvw
 urllib3==2.3.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -234,7 +234,7 @@ typing-extensions==4.12.2
     #   pydantic-core
     #   sqlalchemy
     #   uvicorn
-unicode-segment==0.2.0
+unicode-segment==0.4.2
     # via -r docs/requirements.in
 uritemplate==4.1.1
     # via csvw

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "scipy==1.14.1",
     # Audio processing
     "soundfile==0.13.0",
-    "regex==2024.11.6",
+    "regex==2025.11.3",
     # Utilities
     "aiofiles==23.2.1",
     "tqdm==4.67.1",
@@ -40,6 +40,7 @@ dependencies = [
     "phonemizer-fork>=3.3.2",
     "av>=14.2.0",
     "text2num>=2.5.1",
+    "unicode-segment==0.2.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "phonemizer-fork>=3.3.2",
     "av>=14.2.0",
     "text2num>=2.5.1",
-    "unicode-segment==0.2.0",
+    "unicode-segment==0.4.2",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Fixes https://github.com/remsky/Kokoro-FastAPI/issues/308.

In the end I didn't use ICU directly, since ICU support in Python can be a bit finnicky as a dependency and can't be added with a simple `pip install`.

Instead, I re-implemented the Unicode sentence segmentation algorithm as a pure Python module, [`unicode-segment`](https://pypi.org/project/unicode-segment/). It's a fully compliant implementation (passes all the tests in the TR29 test suite) ~~but kinda slow~~ and, after some optimization, decently performant for inputs of a reasonable size (typically sub-ms per 1k chars, YMMV depending on hardware etc).

It's also a deterministic algorithm, which means there are still [certain corner cases](https://www.regular-expressions.info/unicodeboundaries.html#sentence) it will get wrong:

> UAX #<b></b>29’s sentence boundary rules are a lot smarter than just treating every full stop as the end of a sentence. But they’re not perfect. In the string `"Dr. John works at I.B.M., doesn't he?", asked Alice. "Yes," replied Charlie.`, the regex `\b{sb}.+?\b{sb}` finds 3 matches: `"Dr. `, `John works at I.B.M., doesn't he?", asked Alice. `, and `"Yes," replied Charlie.`. A full stop ends a sentence if it is followed by a capital letter. The question mark does not trigger a sentence break because of the comma that follows, even with the quote in between.

Without using a neural-based approach for sentence segmenting or applying some hacky, ad-hoc solution, there's not much that can be done about these.