### PR TITLE
Use `#!/usr/bin/env bash` in `start-gpu.sh` for better compatibility

### DIFF
--- a/start-gpu.sh
+++ b/start-gpu.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Get project root directory
 PROJECT_ROOT=$(pwd)


### PR DESCRIPTION
For example /bin/bash doesn't exist on NixOS and this works acros distros.