### PR TITLE
Update torch source markers in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,13 +54,10 @@ test = [
     "jinja2>=3.1.6",
 ]
 
-[tool.uv]
-conflicts = [[{ extra = "cpu" }, { extra = "gpu" }]]
-
 [tool.uv.sources]
 torch = [
-    { index = "pytorch-cpu", extra = "cpu" },
-    { index = "pytorch-cuda", extra = "gpu" },
+    { index = "pytorch-cpu", marker = "extra == 'cpu' and extra != 'gpu'" },
+    { index = "pytorch-cuda", marker = "extra == 'gpu' and extra != 'cpu'" },
 ]
 
 [[tool.uv.index]]


### PR DESCRIPTION
Made the CPU/GPU markers mutually exclusive (extra == 'cpu' and extra != 'gpu' / extra == 'gpu' and extra != 'cpu') to satisfy uv’s “disjoint markers” requirement and let uv sync --extra cpu|gpu pick the right PyTorch index.

Fixes the following error when running uv sync:
```
error: Failed to parse: `pyproject.toml`
    Caused by: TOML parse error at line 62, column 30
     |
  62 |     { index = "pytorch-cpu", extra = "cpu" },
     |                              ^^^^^
  unknown field `extra`, expected one of `git`, `subdirectory`, `rev`, `tag`, `branch`, `url`, `path`, `editable`, `index`, `workspace`, `marker`
```