### PR TITLE
Adds gpt-4o-mini-tts

### DIFF
--- a/api/src/core/openai_mappings.json
+++ b/api/src/core/openai_mappings.json
@@ -2,7 +2,8 @@
     "models": {
         "tts-1": "kokoro-v1_0",
         "tts-1-hd": "kokoro-v1_0",
-        "kokoro": "kokoro-v1_0"
+        "kokoro": "kokoro-v1_0",
+        "gpt-4o-mini-tts": "kokoro-v1_0"
     },
     "voices": {
         "alloy": "am_v0adam",

--- a/api/src/routers/openai_compatible.py
+++ b/api/src/routers/openai_compatible.py
@@ -471,6 +471,12 @@ async def list_models():
                 "created": 1686935002,
                 "owned_by": "kokoro",
             },
+            {
+                "id": "gpt-4o-mini-tts",
+                "object": "model",
+                "created": 1686935002,
+                "owned_by": "kokoro",
+            },
         ]
 
         return {"object": "list", "data": models}


### PR DESCRIPTION
Adds gpt-4o-mini-tts as a supported model, to improve openai compatibility. For example, this makes speech central work with Kokoro-FastAPI.