### PR TITLE
fix: OGG/Opus audio truncation — final page lost in write_chunk finalize

### DIFF
--- a/api/src/services/streaming_audio_writer.py
+++ b/api/src/services/streaming_audio_writer.py
@@ -80,13 +80,15 @@ class StreamingAudioWriter:
                 for packet in packets:
                     self.container.mux(packet)
 
-                # Closing the container handles writing the trailer and finalizing the file.
-                # No explicit flush method is available or needed here.
-                logger.debug("Muxed final packets.")
+                # Close the container FIRST — this writes the final OGG page
+                # (or other format trailer) to the output buffer. For OGG/Opus,
+                # the last page of audio data is only written during close().
+                self.container.close()
+                logger.debug("Closed container, final page/trailer written.")
 
-                # Get the final bytes from the buffer *before* closing it
+                # Now read the buffer which includes all trailing data
                 data = self.output_buffer.getvalue()
-                self.close() # Close container and buffer
+                self.output_buffer.close()
                 return data
 
         if audio_data is None or len(audio_data) == 0:


### PR DESCRIPTION
## Summary

**One-line fix**: `container.close()` must be called **before** `output_buffer.getvalue()` in the `write_chunk` finalize block. The current order loses the final OGG page containing ~1-2 seconds of audio.

## The Bug

When using `response_format: "opus"` on `/v1/audio/speech`, output audio is consistently truncated. The last 1-2 seconds are silently dropped. All other formats (MP3, WAV, FLAC, PCM) work correctly.

**Related issue**: #447

## Root Cause

In `api/src/services/streaming_audio_writer.py`, the finalize block does:

```python
# ❌ BEFORE (broken)
data = self.output_buffer.getvalue()  # reads buffer BEFORE final page is written
self.close()                           # closes container, writing final OGG page to buffer (too late)
return data                            # returns incomplete audio
```

For OGG/Opus, the container writes the **final audio page** to the output buffer during `close()`. By reading the buffer first, that last page is lost. MP3/WAV/FLAC aren't affected because their container close only writes metadata trailers, not audio frames.

## Fix

```python
# ✅ AFTER (fixed)
self.container.close()                 # writes final OGG page to buffer
data = self.output_buffer.getvalue()   # now includes all audio data
self.output_buffer.close()
return data
```

## Test Results

Same text, same voice, same speed — only `response_format` differs:

### Before fix
| Text | MP3 duration | Opus duration | Lost |
|---|---|---|---|
| Short | 3.408s | **2.000s** | 1.4s |
| Medium | 5.016s | **3.000s** | 2.0s |
| Long | 10.224s | **9.000s** | 1.2s |

Note the round-number opus durations — OGG pages emit at ~1s granule boundaries, and the final partial page was being dropped.

### After fix
| Text | MP3 duration | Opus duration | Delta |
|---|---|---|---|
| Short | 3.408s | **3.347s** | 0.06s ✅ |
| Medium | 5.016s | **4.959s** | 0.06s ✅ |
| Long | 10.224s | **10.163s** | 0.06s ✅ |

Durations now match within ~60ms (normal codec framing overhead).

## Changed Files

- `api/src/services/streaming_audio_writer.py` — 10 lines changed in `write_chunk()` finalize block

## Testing

- Tested on GPU Docker build (CUDA 12.9.1, PyTorch)
- Verified with voice blending (`am_puck(1)+am_liam(1)+am_onyx(0.5)` at 1.2x speed)
- Confirmed MP3/WAV/FLAC output unchanged
- Sent fixed opus output as Discord voice messages — plays completely, no cutoff
