### PR TITLE
fix: use weights_only=True for voice tensor torch.load calls

### DIFF
--- a/api/src/core/paths.py
+++ b/api/src/core/paths.py
@@ -160,7 +160,7 @@ async def list_voices() -> List[str]:
 
 
 async def load_voice_tensor(
-    voice_path: str, device: str = "cpu", weights_only=False
+    voice_path: str, device: str = "cpu", weights_only=True
 ) -> torch.Tensor:
     """Load voice tensor from file.
 

--- a/api/src/services/tts_service.py
+++ b/api/src/services/tts_service.py
@@ -174,7 +174,7 @@ class TTSService:
             raise ValueError(f"Voice not found at path: {path}")
 
         logger.debug(f"Loading voice tensor from path: {path}")
-        return torch.load(path, map_location="cpu") * weight
+        return torch.load(path, map_location="cpu", weights_only=True) * weight
 
     async def _get_voices_path(self, voice: str) -> Tuple[str, str]:
         """Get voice path, handling combined voices.


### PR DESCRIPTION
## Summary

Fixes #452 — security hardening of `torch.load()` calls for voice tensor files.

## Problem

Voice `.pt` files are loaded via `torch.load()` with the default `weights_only=False`, which allows arbitrary code execution through crafted pickle payloads. This is a security risk, especially if voice files could be user-provided or if a supply chain compromise introduces malicious `.pt` files.

## Fix

Set `weights_only=True` on all `torch.load()` calls that load voice tensors. Voice `.pt` files contain simple tensors and do not require pickle deserialization.

Note: `load_model_weights()` in `paths.py` already correctly uses `weights_only=True` — this change makes voice loading consistent.

## Changes

- **`api/src/core/paths.py`**: Changed `load_voice_tensor()` default parameter from `weights_only=False` to `weights_only=True`
- **`api/src/services/tts_service.py`**: Added `weights_only=True` to the `torch.load()` call in the `_load_voice` method

## Testing

- Voice `.pt` files in this project contain simple tensor data and are fully compatible with `weights_only=True`
- No callers of `load_voice_tensor()` explicitly pass `weights_only=False`, so changing the default is safe