### PR TITLE
feat(gpu): adds clear cu128 opt-in via compose, setup for Blackwell /…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,6 +85,9 @@ jobs:
           - build_target: "gpu"
             platform: "linux/amd64"
             runs_on: "ubuntu-24.04"
+          - build_target: "gpu-cu128"
+            platform: "linux/amd64"
+            runs_on: "ubuntu-24.04"
           - build_target: "cpu"
             platform: "linux/arm64"
             runs_on: "ubuntu-24.04-arm"
@@ -151,7 +154,7 @@ jobs:
       REPO: ${{ vars.REPO || 'kokoro-fastapi' }}
     strategy:
       matrix:
-        build_target: ["cpu", "gpu", "rocm"]
+        build_target: ["cpu", "gpu", "gpu-cu128", "rocm"]
     steps:
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
@@ -168,25 +171,64 @@ jobs:
           OWNER="${{ env.OWNER }}"
           REPO="${{ env.REPO }}"
 
-          # ROCm is x86-only, so the manifest references just the amd64 image.
-          if [[ "$TARGET" == "rocm" ]]; then
-            SOURCES=("${REGISTRY}/${OWNER}/${REPO}-${TARGET}:${VERSION_TAG}-amd64")
-          else
-            SOURCES=(
-              "${REGISTRY}/${OWNER}/${REPO}-${TARGET}:${VERSION_TAG}-amd64"
-              "${REGISTRY}/${OWNER}/${REPO}-${TARGET}:${VERSION_TAG}-arm64"
-            )
-          fi
+          # Resolve the package name, manifest tag(s), and source images per target.
+          #
+          # Tag layout per target:
+          #  - cpu:        :VERSION + :latest                         (multi-arch)
+          #  - gpu:        :VERSION + :VERSION-cu126 + :latest + :latest-cu126
+          #                  (the -cu126 aliases make the wheel variant explicit so
+          #                  Maxwell/Pascal users can pin it across future default flips)
+          #  - gpu-cu128:  :VERSION-cu128 + :latest-cu128             (amd64 only)
+          #  - rocm:       :VERSION + :latest                         (amd64 only)
+          #
+          # MANIFEST_TAGS / LATEST_TAGS are space-separated lists; all entries point at
+          # the same SOURCES so the underlying blobs are deduplicated by digest.
+          case "$TARGET" in
+            gpu-cu128)
+              PACKAGE="${REPO}-gpu"
+              MANIFEST_TAGS="${VERSION_TAG}-cu128"
+              LATEST_TAGS="latest-cu128"
+              SOURCES=("${REGISTRY}/${OWNER}/${PACKAGE}:${VERSION_TAG}-cu128-amd64")
+              ;;
+            gpu)
+              PACKAGE="${REPO}-gpu"
+              MANIFEST_TAGS="${VERSION_TAG} ${VERSION_TAG}-cu126"
+              LATEST_TAGS="latest latest-cu126"
+              SOURCES=(
+                "${REGISTRY}/${OWNER}/${PACKAGE}:${VERSION_TAG}-amd64"
+                "${REGISTRY}/${OWNER}/${PACKAGE}:${VERSION_TAG}-arm64"
+              )
+              ;;
+            rocm)
+              PACKAGE="${REPO}-rocm"
+              MANIFEST_TAGS="${VERSION_TAG}"
+              LATEST_TAGS="latest"
+              SOURCES=("${REGISTRY}/${OWNER}/${PACKAGE}:${VERSION_TAG}-amd64")
+              ;;
+            *)
+              PACKAGE="${REPO}-${TARGET}"
+              MANIFEST_TAGS="${VERSION_TAG}"
+              LATEST_TAGS="latest"
+              SOURCES=(
+                "${REGISTRY}/${OWNER}/${PACKAGE}:${VERSION_TAG}-amd64"
+                "${REGISTRY}/${OWNER}/${PACKAGE}:${VERSION_TAG}-arm64"
+              )
+              ;;
+          esac
 
-          docker buildx imagetools create -t \
-            ${REGISTRY}/${OWNER}/${REPO}-${TARGET}:${VERSION_TAG} \
-            "${SOURCES[@]}"
-
-          # Publish :latest only for clean release tags (no branch suffix).
-          if [[ "$VERSION_TAG" != *"-"* ]]; then
+          for TAG in $MANIFEST_TAGS; do
             docker buildx imagetools create -t \
-              ${REGISTRY}/${OWNER}/${REPO}-${TARGET}:latest \
+              ${REGISTRY}/${OWNER}/${PACKAGE}:${TAG} \
               "${SOURCES[@]}"
+          done
+
+          # Publish the rolling tag(s) only for clean release tags (no branch suffix).
+          if [[ "$VERSION_TAG" != *"-"* ]]; then
+            for TAG in $LATEST_TAGS; do
+              docker buildx imagetools create -t \
+                ${REGISTRY}/${OWNER}/${PACKAGE}:${TAG} \
+                "${SOURCES[@]}"
+            done
           fi
 
   create-release:

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -15,6 +15,7 @@ on:
           - all
           - cpu
           - gpu
+          - gpu-cu128
           - rocm
       platform:
         description: 'Platform (ignored for rocm)'
@@ -48,6 +49,7 @@ jobs:
             {"build_target":"cpu","platform":"arm64","runs_on":"ubuntu-24.04-arm"},
             {"build_target":"gpu","platform":"amd64","runs_on":"ubuntu-24.04"},
             {"build_target":"gpu","platform":"arm64","runs_on":"ubuntu-24.04-arm"},
+            {"build_target":"gpu-cu128","platform":"amd64","runs_on":"ubuntu-24.04"},
             {"build_target":"rocm","platform":"amd64","runs_on":"ubuntu-24.04"}
           ]'
           

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Per-PR attribution and contributor credits are published automatically on the co
 
 ## [v0.3.1] - Unreleased
 ### Added
+- GPU image variants for Blackwell / RTX 50-series (`:latest-cu128`, `:vX.Y.Z-cu128`, amd64 only) with PyTorch cu128 wheels (#443). Default `:latest` and new `:latest-cu126` alias stay on cu126 for Maxwell/Pascal compatibility.
 - Integration test suite (`api/tests/integration/`, opt-in `integration` marker) and a `tts-api-test-client` image that round-trips speech through faster-whisper against a live server. Run via `docker/docker-compose.test.yml`.
 - Web UI footer badge showing the server version from `/config`.
 

--- a/README.md
+++ b/README.md
@@ -42,8 +42,11 @@ Refer to the core/config.py file for a full list of variables which can be manag
 
 docker run -p 8880:8880 ghcr.io/remsky/kokoro-fastapi-cpu:latest # CPU, or:
 docker run --gpus all -p 8880:8880 ghcr.io/remsky/kokoro-fastapi-gpu:latest  # NVIDIA GPU, or:
+docker run --gpus all -p 8880:8880 ghcr.io/remsky/kokoro-fastapi-gpu:latest-cu128  # NVIDIA Blackwell / RTX 50-series, or:
 docker run --device=/dev/kfd --device=/dev/dri -p 8880:8880 ghcr.io/remsky/kokoro-fastapi-rocm:latest  # AMD GPU (ROCm, experimental, amd64 only)
 ```
+
+> `:latest` defaults to cu126 (multi-arch, also published as `:latest-cu126`). `:latest-cu128` is the Blackwell / RTX 50-series variant (PyTorch cu128, amd64 only). Same suffixes on versioned tags.
 
 
 </details>

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -106,7 +106,9 @@ target "gpu-cu128-amd64" {
     inherits = ["_gpu_base"]
     platforms = ["linux/amd64"]
     args = {
-        CUDA_VERSION = "12.9.1"
+        # 12.8.x is the first CUDA toolkit with Blackwell (sm_120) support and is
+        # what the cu128 torch wheels are built against. Keep base + wheel aligned.
+        CUDA_VERSION = "12.8.1"
         GPU_EXTRA = "gpu-cu128"
     }
     tags = [
@@ -140,7 +142,7 @@ target "gpu-cu128-dev" {
     inherits = ["_gpu_base"]
     # No multi-platform for dev builds
     args = {
-        CUDA_VERSION = "12.9.1"
+        CUDA_VERSION = "12.8.1"
         GPU_EXTRA = "gpu-cu128"
     }
     tags = ["${REGISTRY}/${OWNER}/${REPO}-gpu:dev-cu128"]

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -100,6 +100,20 @@ target "gpu-arm64" {
     ]
 }
 
+# Blackwell / RTX 50-series variant: cu128 torch wheels (sm_120 kernels).
+# x86_64 only; published as a -cu128 suffixed tag on the existing -gpu package.
+target "gpu-cu128-amd64" {
+    inherits = ["_gpu_base"]
+    platforms = ["linux/amd64"]
+    args = {
+        CUDA_VERSION = "12.9.1"
+        GPU_EXTRA = "gpu-cu128"
+    }
+    tags = [
+        "${REGISTRY}/${OWNER}/${REPO}-gpu:${VERSION}-cu128-amd64"
+    ]
+}
+
 # AMD ROCm only supports x86
 target "rocm-amd64" {
     inherits = ["_rocm_base"]
@@ -122,6 +136,16 @@ target "gpu-dev" {
     tags = ["${REGISTRY}/${OWNER}/${REPO}-gpu:dev"]
 }
 
+target "gpu-cu128-dev" {
+    inherits = ["_gpu_base"]
+    # No multi-platform for dev builds
+    args = {
+        CUDA_VERSION = "12.9.1"
+        GPU_EXTRA = "gpu-cu128"
+    }
+    tags = ["${REGISTRY}/${OWNER}/${REPO}-gpu:dev-cu128"]
+}
+
 group "dev" {
     targets = ["cpu-dev", "gpu-dev"]
 }
@@ -132,7 +156,7 @@ group "cpu-all" {
 }
 
 group "gpu-all" {
-    targets = ["gpu-amd64", "gpu-arm64"]
+    targets = ["gpu-amd64", "gpu-arm64", "gpu-cu128-amd64"]
 }
 
 group "rocm-all" {
@@ -140,9 +164,9 @@ group "rocm-all" {
 }
 
 group "all" {
-    targets = ["cpu", "gpu-amd64", "gpu-arm64", "rocm-amd64"]
+    targets = ["cpu", "gpu-amd64", "gpu-arm64", "gpu-cu128-amd64", "rocm-amd64"]
 }
 
 group "individual-platforms" {
-    targets = ["cpu-amd64", "cpu-arm64", "gpu-amd64", "gpu-arm64", "rocm-amd64"]
+    targets = ["cpu-amd64", "cpu-arm64", "gpu-amd64", "gpu-arm64", "gpu-cu128-amd64", "rocm-amd64"]
 }

--- a/docker/gpu/Dockerfile.optimized
+++ b/docker/gpu/Dockerfile.optimized
@@ -24,8 +24,13 @@ COPY pyproject.toml ./pyproject.toml
 ENV UV_HTTP_TIMEOUT=120 UV_HTTP_RETRIES=3 \
     UV_PYTHON_INSTALL_DIR=/opt/uv-python
 
+# GPU_EXTRA selects the torch wheel set: "gpu" (cu126, keeps Maxwell/Pascal
+# working) or "gpu-cu128" (cu128, adds Blackwell / RTX 50-series). Overridden
+# per target in docker-bake.hcl.
+ARG GPU_EXTRA=gpu
+
 RUN uv venv --python 3.10 && \
-    uv sync --extra gpu --no-cache --no-install-project
+    uv sync --extra ${GPU_EXTRA} --no-cache --no-install-project
 
 # Stage 2: Runtime - Use smaller runtime image
 FROM --platform=$BUILDPLATFORM nvcr.io/nvidia/cuda:${CUDA_VERSION}-cudnn-runtime-ubuntu24.04

--- a/docker/gpu/docker-compose.yml
+++ b/docker/gpu/docker-compose.yml
@@ -5,6 +5,11 @@ services:
     build:
       context: ../..
       dockerfile: docker/gpu/Dockerfile.optimized
+      # Default builds cu126 wheels, multi-arch (Maxwell through Ada: GTX 9xx, 10xx, 20xx, 30xx, 40xx).
+      # Temp fix for NVIDIA Blackwell / RTX 50-series, uncomment:
+      # args:
+      #   GPU_EXTRA: gpu-cu128
+      #   CUDA_VERSION: 12.9.1
     volumes:
       - ../../api:/app/api
     user: "1001:1001"  # Ensure container runs as UID 1001 (appuser)

--- a/docker/gpu/docker-compose.yml
+++ b/docker/gpu/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       # Temp fix for NVIDIA Blackwell / RTX 50-series, uncomment:
       # args:
       #   GPU_EXTRA: gpu-cu128
-      #   CUDA_VERSION: 12.9.1
+      #   CUDA_VERSION: 12.8.1
     volumes:
       - ../../api:/app/api
     user: "1001:1001"  # Ensure container runs as UID 1001 (appuser)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,13 @@ gpu = [
     "torch==2.8.0+cu126 ; platform_machine == 'x86_64'",
     "torch==2.8.0+cu129 ; platform_machine == 'aarch64'",
 ]
+# Blackwell / RTX 50-series variant. cu128 wheels carry sm_120 kernels but
+# drop Maxwell/Pascal, so this is a separate extra rather than the default.
+# See #443. aarch64 already ships cu129 (Blackwell-capable) under both extras.
+gpu-cu128 = [
+    "torch==2.8.0+cu128 ; platform_machine == 'x86_64'",
+    "torch==2.8.0+cu129 ; platform_machine == 'aarch64'",
+]
 cpu = ["torch==2.8.0"]
 rocm = [
     "torch==2.8.0+rocm6.4",
@@ -70,6 +77,7 @@ conflicts = [
     [
         { extra = "cpu" },
         { extra = "gpu" },
+        { extra = "gpu-cu128" },
         { extra = "rocm" },
     ],
 ]
@@ -82,6 +90,8 @@ torch = [
     { index = "pytorch-cpu", extra = "cpu" },
     { index = "pytorch-cu126", extra = "gpu", marker = "platform_machine == 'x86_64'" },
     { index = "pytorch-cu129", extra = "gpu", marker = "platform_machine == 'aarch64'" },
+    { index = "pytorch-cu128", extra = "gpu-cu128", marker = "platform_machine == 'x86_64'" },
+    { index = "pytorch-cu129", extra = "gpu-cu128", marker = "platform_machine == 'aarch64'" },
     { index = "pytorch-rocm", extra = "rocm" },
 ]
 pytorch-triton-rocm = [
@@ -96,6 +106,11 @@ explicit = true
 [[tool.uv.index]]
 name = "pytorch-cu126"
 url = "https://download.pytorch.org/whl/cu126"
+explicit = true
+
+[[tool.uv.index]]
+name = "pytorch-cu128"
+url = "https://download.pytorch.org/whl/cu128"
 explicit = true
 
 [[tool.uv.index]]


### PR DESCRIPTION
Adds a -cu128 tag to the -gpu package while keeping the default -gpu image on cu126 for Maxwell/Pascal compatibility. 

Explicit -cu126 aliases added to allow stable pinning against future default changes. 
Compose users opt into cu128 by uncommenting preset args block in docker/gpu/docker-compose.yml.