### PR TITLE
fix(audio): drop WAV close()-time junk trailer that caused chunk-end click #463

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Per-PR attribution and contributor credits are published automatically on the co
 - Removed the legacy `docker/{cpu,gpu}/Dockerfile`; the `.optimized` variants are the only build files now.
 
 ### Fixed
+- WAV responses drop junk size-field trailer that decoded as a click at chunk end. (#463)
 - cpu/gpu composes set `DOWNLOAD_MODEL=true` for an idempotent model fetch on startup.
 - Silence trimming no longer treats full-scale-negative samples as silent (`int16` `abs()` overflow).
 - Fixed invalid escape sequences in the text-normalizer URL regex.

--- a/README.md
+++ b/README.md
@@ -2,11 +2,10 @@
   <img src="githubbanner.png" alt="Kokoro TTS Banner">
 </p>
 
-# <sub><sub>_`FastKoko`_ </sub></sub>
-[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/remsky/Kokoro-FastAPI) [![Ask CodeWiki](https://img.shields.io/badge/Ask%20CodeWiki-4285F4?logo=googlegemini&logoColor=white)](https://codewiki.google/github.com/remsky/kokoro-fastapi)
+# <sub><sub>_`FastKoko`_ </sub></sub> 
 
-[![Tests](https://img.shields.io/badge/tests-81-darkgreen)]()
-[![Coverage](https://img.shields.io/badge/coverage-52%25-tan)]() [![Changelog](https://img.shields.io/badge/changelog-white)](./CHANGELOG.md)
+  [![Changelog](https://img.shields.io/badge/changelog-white)](./CHANGELOG.md) [![Tests](https://img.shields.io/badge/tests-81-darkgreen)]()
+[![Coverage](https://img.shields.io/badge/coverage-52%25-tan)]() [![Downloads](https://img.shields.io/badge/downloads-1.4M%2B-2496ED?logo=docker&logoColor=white)](https://github.com/remsky?tab=packages&repo_name=Kokoro-FastAPI)
 
 [![Kokoro](https://img.shields.io/badge/kokoro-0.9.4-BB5420)](https://github.com/hexgrad/kokoro)
 [![Misaki](https://img.shields.io/badge/misaki-0.9.4-B8860B)](https://github.com/hexgrad/misaki)
@@ -26,6 +25,8 @@ Dockerized FastAPI wrapper for [Kokoro-82M](https://huggingface.co/hexgrad/Kokor
 
 
 ### Integration Guides
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/remsky/Kokoro-FastAPI) [![Ask CodeWiki](https://img.shields.io/badge/Ask%20CodeWiki-4285F4?logo=googlegemini&logoColor=white)](https://codewiki.google/github.com/remsky/kokoro-fastapi)
+
  [![Helm Chart](https://img.shields.io/badge/Helm%20Chart-black?style=flat&logo=helm&logoColor=white)](https://github.com/remsky/Kokoro-FastAPI/wiki/Setup-Kubernetes) [![DigitalOcean](https://img.shields.io/badge/DigitalOcean-black?style=flat&logo=digitalocean&logoColor=white)](https://github.com/remsky/Kokoro-FastAPI/wiki/Integrations-DigitalOcean) [![SillyTavern](https://img.shields.io/badge/SillyTavern-black?style=flat&color=red)](https://github.com/remsky/Kokoro-FastAPI/wiki/Integrations-SillyTavern)
 [![OpenWebUI](https://img.shields.io/badge/OpenWebUI-black?style=flat&color=white)](https://github.com/remsky/Kokoro-FastAPI/wiki/Integrations-OpenWebUi)
 ## Get Started

--- a/api/src/services/streaming_audio_writer.py
+++ b/api/src/services/streaming_audio_writer.py
@@ -80,7 +80,7 @@ class StreamingAudioWriter:
                 for packet in packets:
                     self.container.mux(packet)
 
-                # Close the container FIRST — this writes the final OGG page
+                # Close the container FIRST. this writes the final OGG page
                 # (or other format trailer) to the output buffer. For OGG/Opus,
                 # the last page of audio data is only written during close().
                 self.container.close()
@@ -89,6 +89,12 @@ class StreamingAudioWriter:
                 # Now read the buffer which includes all trailing data
                 data = self.output_buffer.getvalue()
                 self.output_buffer.close()
+
+                if self.format == "wav":
+                    # close()'s seek-and-patch lands ~78 bytes of size-field
+                    # junk in the truncated buffer. Decoded as samples it's
+                    # an audible click at chunk end. issue #463.
+                    return b""
                 return data
 
         if audio_data is None or len(audio_data) == 0:

--- a/web/src/services/AudioService.js
+++ b/web/src/services/AudioService.js
@@ -156,7 +156,7 @@ export class AudioService {
         this.audio.src = this.objectUrl;
 
         this.audio.addEventListener('error', () => {
-            console.error('Audio error:', this.audio.error);
+            console.error('Audio error:', this.audio?.error);
         });
 
         this.audio.addEventListener('ended', () => {


### PR DESCRIPTION
 WAV responses no longer carry a junk size-field trailer that decoded as a click at chunk end. Previously noticeable when concatenating per-sentence WAVs (e.g. wyoming-openai + Home Assistant). (#463)  