### PR TITLE
Prevent POST /dev/unload behind an opt-in setting

### DIFF
--- a/api/src/core/config.py
+++ b/api/src/core/config.py
@@ -40,6 +40,7 @@ class Settings(BaseSettings):
     allow_local_voice_saving: bool = (
         False  # Whether to allow saving combined voices locally
     )
+    allow_dev_unload: bool = False  # Whether to expose the POST /dev/unload endpoint
 
     # Container absolute paths
     model_dir: str = "/app/api/src/models"  # Absolute path in container

--- a/api/src/routers/development.py
+++ b/api/src/routers/development.py
@@ -423,6 +423,11 @@ async def unload_model(
     The model reloads automatically on the next inference request.
     Useful for homelab deployments where GPU memory is shared across services.
     """
+    if not settings.allow_dev_unload:
+        raise HTTPException(
+            status_code=403,
+            detail={"error": "The /dev/unload endpoint is disabled"},
+        )
     try:
         if tts_service.model_manager is None:
             raise HTTPException(status_code=503, detail={"error": "Model manager not initialized"})

--- a/api/tests/test_model_unload.py
+++ b/api/tests/test_model_unload.py
@@ -8,6 +8,7 @@ import numpy as np
 import pytest
 from fastapi.testclient import TestClient
 
+from api.src.core.config import settings
 from api.src.inference.base import AudioChunk
 from api.src.inference.model_manager import ModelManager
 from api.src.main import app
@@ -28,6 +29,12 @@ def override_tts_service(service):
         yield
     finally:
         app.dependency_overrides.pop(get_tts_service, None)
+
+
+@pytest.fixture(autouse=True)
+def _enable_dev_unload(monkeypatch):
+    """Enable the /dev/unload gate for the endpoint tests in this module."""
+    monkeypatch.setattr(settings, "allow_dev_unload", True)
 
 
 # ---------------------------------------------------------------------------
@@ -200,6 +207,20 @@ def test_unload_endpoint_returns_200():
     assert response.status_code == 200
     assert response.json() == {"status": "unloaded"}
     mock_manager.unload.assert_called_once()
+
+
+def test_unload_endpoint_403_when_disabled(monkeypatch):
+    """Returns 403 without touching the model when the gate is off."""
+    monkeypatch.setattr(settings, "allow_dev_unload", False)
+    mock_manager = AsyncMock()
+    mock_manager.unload = AsyncMock()
+    service = _mock_service(manager=mock_manager)
+
+    with override_tts_service(service):
+        response = client.post("/dev/unload")
+
+    assert response.status_code == 403
+    mock_manager.unload.assert_not_called()
 
 
 def test_unload_endpoint_idempotent():


### PR DESCRIPTION
Currently /dev/unload is mounted by default with no authentication, so any caller that can reach the API can unload the active model from memory and can possibly force repeated reload cycles (#478).

Added an `allow_dev_unload` setting (default `False`) and return 403 when disabled. The endpoint is off by default and can be re-enabled with ALLOW_DEV_UNLOAD=true for trusted deployments.

**Testing:** `uv run pytest` (94 tests passed, I have included a new 403-when-disabled test) plus tried live, non-Docker run and I confirm `/dev/unload` returns 403 by default and 200 with `ALLOW_DEV_UNLOAD=true` set.

Did not test via Docker Compose or on CUDA hardware (I have Apple Silicon Mac). The change is a config flag and an early return guard with no docker container or GPU specific paths, but appreciate if someone else can confirm on other environments.
