### PR TITLE
fix(normalizer): expand wh-word 're contractions espeak voices as -ray

### DIFF
--- a/api/src/services/text_processing/normalizer.py
+++ b/api/src/services/text_processing/normalizer.py
@@ -410,6 +410,17 @@ def handle_time(t: re.Match[str]) -> str:
 def normalize_text(text: str, normalization_options: NormalizationOptions) -> str:
     """Normalize text for TTS processing"""
 
+    # Expand the "'re" contractions that espeak mis-phonemizes with a spurious
+    # /ɹeɪ/ ("-ray") ending, e.g. "how're" -> /haʊɹeɪ/ which sounds like "harry".
+    # Only the wh-words and there/these/those break this way; "you're", "we're"
+    # and "they're" already phonemize correctly and are left untouched.
+    text = re.sub(
+        r"\b(how|what|where|who|when|why|there|these|those)['’]re\b",
+        r"\1 are",
+        text,
+        flags=re.IGNORECASE,
+    )
+
     # Handle email addresses first if enabled
     if normalization_options.email_normalization:
         text = EMAIL_PATTERN.sub(handle_email, text)

--- a/api/tests/test_normalizer.py
+++ b/api/tests/test_normalizer.py
@@ -334,3 +334,30 @@ def test_remaining_symbol():
         )
         == "I love buying products at good store here and at other store"
     )
+
+
+def test_re_contraction_expansion():
+    """Wh-word "'re" contractions are expanded so espeak does not voice a
+    spurious "-ray" ending (e.g. "how're" was phonemized like "harry")."""
+    assert (
+        normalize_text(
+            "Hello there, how're you doing this fine day?",
+            normalization_options=NormalizationOptions(),
+        )
+        == "Hello there, how are you doing this fine day?"
+    )
+    assert (
+        normalize_text(
+            "What're these and where're they going?",
+            normalization_options=NormalizationOptions(),
+        )
+        == "What are these and where are they going?"
+    )
+    # Contractions that already phonemize correctly must be left untouched.
+    assert (
+        normalize_text(
+            "You're sure we're not late and they're here?",
+            normalization_options=NormalizationOptions(),
+        )
+        == "You're sure we're not late and they're here?"
+    )


### PR DESCRIPTION
AI assisted (Opus 4.8) but tested in my own running version on my GB10 Spark.

## Description

### The bug

espeak's letter-to-sound gives some `'re` contractions a spurious stressed
`/ɹeɪ/` ("-ray") ending. The clearest example is **"how're"**, which is
phonemized as `hˌWɹˌA` = /haʊ ɹ eɪ/ — "how-**ray**", which listeners hear as
"harry". The trailing `A` is the same `/eɪ/` vowel as "day" (`dˈA`), so the
contraction gets an incorrect diphthong that isn't in the intended word.

This is not voice-specific - it reproduces in both the American (`a`) and
British (`b`) pipelines, because it happens in g2p, upstream of the model.

Phonemes (via `/dev/phonemize`), contracted vs. expanded:

| input        | phonemes        | reads as   |
|--------------|-----------------|------------|
| `how're you` | `hˌWɹˌA juː`     | "how-ray"  |
| `how are you`| `hˌW ɑː juː`     | "how-ah" ✓ |

### The fix

Expand the affected contractions to their two-word form in `normalize_text`
before phonemization. This sits alongside the normalizer's existing always-on
English fixups (`Dr.`→"Doctor", `yeah`→"ye'a", etc.).

The list is deliberately limited to the contractions that actually break -
the wh-words plus `there/these/those`. Common contractions that *already*
phonemize correctly are intentionally left untouched, so this changes nothing
for them:

| contraction | phonemes | verdict |
|-------------|----------|---------|
| `you're`    | `jɔː`    | correct - left alone |
| `we're`     | `wɪə`    | correct - left alone |
| `they're`   | `ðɛː`    | correct - left alone |
| `how're`    | `hˌWɹˌA` | broken → `how are` |
| `what're`   | `wˌɒtɹˌA`| broken → `what are` |
| `where're`  | `wˌɛːɹˌA`| broken → `where are` |
| `who're`    | `hˌuːɹˌA`| broken → `who are` |
| `when're`   | `wˌɛnɹˌA`| broken → `when are` |
| `why're`    | `wˌIɹˌA` | broken → `why are` |
| `there're`  | `ðɛːɹˌA` | broken → `there are` |
| `these're`  | `ðiːzɹˌA`| broken → `these are` |
| `those're`  | `ðQzɹˌA` | broken → `those are` |

The regex is case-insensitive and preserves the leading word's capitalization
(`How're` → `How are`), and matches both the straight (`'`) and typographic
(`’`) apostrophe.

### Audio (before / after)

Same sentence, `bf_emma`, listen to "how're":

- `01_before_nofix.mp3` — this codebase, normalization off (bug) → "harry"
- `02_after_fixed.mp3` — this codebase, with this fix → "how are"
- `03_ab_combined_before_then_after.mp3` — both back-to-back


[01_before_nofix.mp3](https://github.com/user-attachments/files/29946112/01_before_nofix.mp3)
[02_after_fixed.mp3](https://github.com/user-attachments/files/29946111/02_after_fixed.mp3)
[03_ab_combined_before_then_after.mp3](https://github.com/user-attachments/files/29946116/03_ab_combined_before_then_after.mp3)
