### PR TITLE
fix: honour default_voice_code in _split_multi_voice

### DIFF
--- a/api/src/services/tts_service.py
+++ b/api/src/services/tts_service.py
@@ -291,8 +291,12 @@ class TTSService:
                 resolved[segment_voice] = await self.get_voices_path(segment_voice)
             voice_name, voice_path = resolved[segment_voice]
 
-            # request lang_code wins, else each speaker gets the pipeline their prefix implies
-            segment_lang = lang_code if lang_code else segment_voice[:1].lower()
+            # request lang_code wins, then default_voice_code setting, else each speaker gets the pipeline their prefix implies
+            segment_lang = (
+                lang_code
+                or settings.default_voice_code
+                or segment_voice[:1].lower()
+            )
             logger.debug(
                 f"Using voice path '{voice_path}' with lang_code '{segment_lang}'"
             )

--- a/api/tests/test_tts_service.py
+++ b/api/tests/test_tts_service.py
@@ -224,6 +224,78 @@ async def test_split_multi_voice_lang_code_per_speaker():
 
 
 @pytest.mark.asyncio
+async def test_split_multi_voice_default_voice_code_used_when_no_lang_code():
+    """settings.default_voice_code is used when no explicit lang_code is given.
+
+    Regression test for issue #514: voices whose filename does not begin with a
+    recognised language code were silently matched against the wrong pipeline
+    (or produced empty audio) because default_voice_code was never consulted.
+    """
+    model_manager = AsyncMock()
+    voice_manager = AsyncMock()
+
+    with (
+        patch("api.src.services.tts_service.get_model_manager") as mock_get_model,
+        patch("api.src.services.tts_service.get_voice_manager") as mock_get_voice,
+        patch("api.src.services.tts_service.settings") as mock_settings,
+    ):
+        mock_get_model.return_value = model_manager
+        mock_get_voice.return_value = voice_manager
+        mock_settings.default_voice_code = "a"
+        mock_settings.voice_weight_normalization = True
+
+        service = await TTSService.create()
+        # "ursa" does not start with a valid lang prefix; without the fix it
+        # resolves to "u", which is not a Kokoro pipeline and yields empty audio.
+        service.get_voices_path = AsyncMock(
+            side_effect=lambda voice: (voice, f"/path/to/{voice}.pt")
+        )
+
+        langs = [
+            lang
+            async for _name, _path, lang, _rate, _text, _tokens, _pause in (
+                service._split_multi_voice("Hello.", "ursa", None, None)
+            )
+        ]
+
+        assert langs == ["a"], (
+            "default_voice_code should be used when lang_code is absent and the "
+            "voice name has no recognised language prefix"
+        )
+
+
+@pytest.mark.asyncio
+async def test_split_multi_voice_explicit_lang_code_beats_default():
+    """An explicit request lang_code takes priority over settings.default_voice_code."""
+    model_manager = AsyncMock()
+    voice_manager = AsyncMock()
+
+    with (
+        patch("api.src.services.tts_service.get_model_manager") as mock_get_model,
+        patch("api.src.services.tts_service.get_voice_manager") as mock_get_voice,
+        patch("api.src.services.tts_service.settings") as mock_settings,
+    ):
+        mock_get_model.return_value = model_manager
+        mock_get_voice.return_value = voice_manager
+        mock_settings.default_voice_code = "a"
+        mock_settings.voice_weight_normalization = True
+
+        service = await TTSService.create()
+        service.get_voices_path = AsyncMock(
+            side_effect=lambda voice: (voice, f"/path/to/{voice}.pt")
+        )
+
+        langs = [
+            lang
+            async for _name, _path, lang, _rate, _text, _tokens, _pause in (
+                service._split_multi_voice("Hello.", "ursa", "b", None)
+            )
+        ]
+
+        assert langs == ["b"], "explicit lang_code must win over default_voice_code"
+
+
+@pytest.mark.asyncio
 async def test_split_multi_voice_explicit_lang_code_wins():
     """An explicit request lang_code overrides every speaker's prefix."""
     model_manager = AsyncMock()


### PR DESCRIPTION
## Summary

- `_split_multi_voice()` in `api/src/services/tts_service.py` computed `segment_lang` from the first character of the voice name when no explicit `lang_code` was provided, skipping `settings.default_voice_code` entirely.
- Voices whose filename does not start with a recognised Kokoro language code (e.g. `ursa`, `eve`, `iris`) were therefore routed to the wrong phonemiser pipeline, returning HTTP 200 with an empty body.
- The fix mirrors the precedence already used in `kokoro_v1.py`: `lang_code` > `settings.default_voice_code` > `voice[:1]`.

Fixes #514

## Changes

**`api/src/services/tts_service.py`** (line ~295)

Before:
```python
segment_lang = lang_code if lang_code else segment_voice[:1].lower()
```

After:
```python
segment_lang = (
    lang_code
    or settings.default_voice_code
    or segment_voice[:1].lower()
)
```

**`api/tests/test_tts_service.py`**

Two new unit tests added alongside the existing `_split_multi_voice` tests:
- `test_split_multi_voice_default_voice_code_used_when_no_lang_code` -- verifies that a voice named `ursa` (no language prefix) uses `settings.default_voice_code` when no `lang_code` is passed.
- `test_split_multi_voice_explicit_lang_code_beats_default` -- verifies that an explicit `lang_code` still wins over `settings.default_voice_code`.

## Test plan

- [x] Reviewed that `settings` is already imported in `tts_service.py` (line 15)
- [x] Verified the fix matches the precedence in `kokoro_v1.py`
- [x] Added unit tests following the existing mock/AsyncMock pattern in `test_tts_service.py`
- [x] Confirmed no other callers of `_split_multi_voice` are affected (the precedence is strictly additive)