### PR TITLE
ROCm performance: disable MIOpen, which compiles a kernel per shape.

### DIFF
--- a/api/src/core/config.py
+++ b/api/src/core/config.py
@@ -36,6 +36,7 @@ class Settings(BaseSettings):
     device_type: str | None = (
         None  # Will be auto-detected if None, can be "cuda", "mps", or "cpu"
     )
+    enable_miopen: bool = False  # ROCm only: MIOpen compiles a kernel per unseen tensor shape, which negatively impacts performance as Kokoro hits it every request
     allow_local_voice_saving: bool = (
         False  # Whether to allow saving combined voices locally
     )

--- a/api/src/inference/kokoro_v1.py
+++ b/api/src/inference/kokoro_v1.py
@@ -80,6 +80,26 @@ def _espeak_word_timestamps(graphemes, phonemes, pred_dur, g2p=None):
         return None
 
 
+def _configure_rocm_backend() -> None:
+    """Disable MIOpen on ROCm.
+
+    MIOpen compiles a kernel per unseen tensor shape, and Kokoro's decoder
+    length varies with the input text, so nearly every request pays that
+    compile: 2433ms per generation against 268ms without, on gfx1100.
+    warmup_miopen.py does not help, as shape is not a function of phoneme
+    count.
+
+    KOKORO_ENABLE_MIOPEN=1 keeps MIOpen. CUDA is unaffected.
+    """
+    if not torch.version.hip:
+        return
+    if os.getenv("KOKORO_ENABLE_MIOPEN", "").lower() in ("1", "true", "yes"):
+        logger.info("MIOpen left enabled via KOKORO_ENABLE_MIOPEN")
+        return
+    torch.backends.cudnn.enabled = False
+    logger.info("ROCm detected: MIOpen disabled to avoid per-shape kernel compilation")
+
+
 class KokoroV1(BaseModelBackend):
     """Kokoro backend with controlled resource management."""
 
@@ -141,6 +161,8 @@ class KokoroV1(BaseModelBackend):
                 )
                 self._model = self._model.to(torch.device("mps"))
             elif self._device == "cuda":
+                # ROCm reports device "cuda", so this is the ROCm path too.
+                _configure_rocm_backend()
                 self._model = self._model.cuda()
             else:
                 self._model = self._model.cpu()

--- a/api/src/inference/kokoro_v1.py
+++ b/api/src/inference/kokoro_v1.py
@@ -89,12 +89,12 @@ def _configure_rocm_backend() -> None:
     warmup_miopen.py does not help, as shape is not a function of phoneme
     count.
 
-    KOKORO_ENABLE_MIOPEN=1 keeps MIOpen. CUDA is unaffected.
+    ENABLE_MIOPEN=true keeps MIOpen. CUDA is unaffected.
     """
     if not torch.version.hip:
         return
-    if os.getenv("KOKORO_ENABLE_MIOPEN", "").lower() in ("1", "true", "yes"):
-        logger.info("MIOpen left enabled via KOKORO_ENABLE_MIOPEN")
+    if settings.enable_miopen:
+        logger.info("MIOpen left enabled via ENABLE_MIOPEN")
         return
     torch.backends.cudnn.enabled = False
     logger.info("ROCm detected: MIOpen disabled to avoid per-shape kernel compilation")

--- a/api/tests/test_kokoro_v1.py
+++ b/api/tests/test_kokoro_v1.py
@@ -7,7 +7,7 @@ import pytest
 import torch
 
 from api.src.core.config import settings
-from api.src.inference.kokoro_v1 import KokoroV1
+from api.src.inference.kokoro_v1 import KokoroV1, _configure_rocm_backend
 
 
 @pytest.fixture
@@ -225,3 +225,38 @@ def test_espeak_word_timestamps_degenerate_inputs():
     assert _espeak_word_timestamps("", "abc", torch.tensor([0, 4, 4, 4, 0])) is None
     # pred_dur too short for the phoneme string.
     assert _espeak_word_timestamps("hola", "abcdef", torch.tensor([0, 4])) is None
+
+
+@pytest.fixture
+def restore_cudnn():
+    """Restore the global flag that _configure_rocm_backend mutates."""
+    previous = torch.backends.cudnn.enabled
+    yield
+    torch.backends.cudnn.enabled = previous
+
+
+def test_configure_rocm_backend_noop_on_cuda(restore_cudnn, monkeypatch):
+    """A CUDA build must keep cuDNN enabled."""
+    monkeypatch.setattr(torch.version, "hip", None)
+    torch.backends.cudnn.enabled = True
+    _configure_rocm_backend()
+    assert torch.backends.cudnn.enabled is True
+
+
+def test_configure_rocm_backend_disables_miopen_on_rocm(restore_cudnn, monkeypatch):
+    """A ROCm build disables MIOpen to avoid per-shape kernel compilation."""
+    monkeypatch.setattr(torch.version, "hip", "7.2.0")
+    monkeypatch.delenv("KOKORO_ENABLE_MIOPEN", raising=False)
+    torch.backends.cudnn.enabled = True
+    _configure_rocm_backend()
+    assert torch.backends.cudnn.enabled is False
+
+
+@pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes"])
+def test_configure_rocm_backend_opt_out(restore_cudnn, monkeypatch, value):
+    """KOKORO_ENABLE_MIOPEN keeps MIOpen in play."""
+    monkeypatch.setattr(torch.version, "hip", "7.2.0")
+    monkeypatch.setenv("KOKORO_ENABLE_MIOPEN", value)
+    torch.backends.cudnn.enabled = True
+    _configure_rocm_backend()
+    assert torch.backends.cudnn.enabled is True

--- a/api/tests/test_kokoro_v1.py
+++ b/api/tests/test_kokoro_v1.py
@@ -246,17 +246,16 @@ def test_configure_rocm_backend_noop_on_cuda(restore_cudnn, monkeypatch):
 def test_configure_rocm_backend_disables_miopen_on_rocm(restore_cudnn, monkeypatch):
     """A ROCm build disables MIOpen to avoid per-shape kernel compilation."""
     monkeypatch.setattr(torch.version, "hip", "7.2.0")
-    monkeypatch.delenv("KOKORO_ENABLE_MIOPEN", raising=False)
+    monkeypatch.setattr(settings, "enable_miopen", False)
     torch.backends.cudnn.enabled = True
     _configure_rocm_backend()
     assert torch.backends.cudnn.enabled is False
 
 
-@pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes"])
-def test_configure_rocm_backend_opt_out(restore_cudnn, monkeypatch, value):
-    """KOKORO_ENABLE_MIOPEN keeps MIOpen in play."""
+def test_configure_rocm_backend_opt_out(restore_cudnn, monkeypatch):
+    """ENABLE_MIOPEN keeps MIOpen active."""
     monkeypatch.setattr(torch.version, "hip", "7.2.0")
-    monkeypatch.setenv("KOKORO_ENABLE_MIOPEN", value)
+    monkeypatch.setattr(settings, "enable_miopen", True)
     torch.backends.cudnn.enabled = True
     _configure_rocm_backend()
     assert torch.backends.cudnn.enabled is True

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -151,6 +151,12 @@ Names are the field names from `api/src/core/config.py`, uppercased. Unrecognize
 | `MAX_TEMP_DIR_AGE_HOURS` | `1` | Prune temp files older than this |
 | `MAX_TEMP_DIR_COUNT` | `3` | Keep at most this many temp files |
 
+**Hardware**
+
+| Variable | Default | |
+|---|---|---|
+| `KOKORO_ENABLE_MIOPEN` | unset | Keep MIOpen enabled on ROCm. Off by default because MIOpen compiles a kernel per tensor shape, which Kokoro hits on nearly every request |
+
 **Operational routes**
 
 | Variable | Default | |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -155,7 +155,7 @@ Names are the field names from `api/src/core/config.py`, uppercased. Unrecognize
 
 | Variable | Default | |
 |---|---|---|
-| `KOKORO_ENABLE_MIOPEN` | unset | Keep MIOpen enabled on ROCm. Off by default because MIOpen compiles a kernel per tensor shape, which Kokoro hits on nearly every request |
+| `ENABLE_MIOPEN` | `false` | Keep MIOpen enabled on ROCm. Off by default because MIOpen compiles a kernel per tensor shape, which negatively impacts performance as Kokoro hits it every request |
 
 **Operational routes**
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -112,18 +112,25 @@ hipBLASLt does not cover every architecture. Falling back to hipBLAS is slower o
 
 ### First request is slow
 
-MIOpen searches for a kernel per unique tensor shape, which costs 5-60s a shape. The image ships `MIOPEN_FIND_MODE=2` and prebaked kernel databases, but only for the architectures listed in `docker/rocm/kdb_install.sh` (CDNA plus gfx1030). RDNA 3 has no prebaked database, so the search runs on first use.
+MIOpen compiles a kernel per unique tensor shape, which costs 5-60s a shape. Kokoro's decoder length is derived from predicted durations, so it changes with the input text and most requests hit a shape that has never been seen.
+
+Because of that, MIOpen is **disabled by default on ROCm**; PyTorch's shape-independent kernels are used instead. Measured on gfx1100 / ROCm 7.2, six novel texts: 2433ms per generation with MIOpen, 268ms without. If first requests are still slow, check the startup log for `MIOpen disabled`.
+
+To go back to MIOpen, set `KOKORO_ENABLE_MIOPEN=1`. The image ships `MIOPEN_FIND_MODE=2` and prebaked kernel databases, but only for the architectures listed in `docker/rocm/kdb_install.sh` (CDNA plus gfx1030). RDNA 3 has no prebaked database, so the search runs on first use.
 
 To pre-populate the on-disk cache, which `docker/rocm/docker-compose.yml` persists in named volumes:
 
 ```bash
 cd docker/rocm
 docker compose run --rm \
+  -e KOKORO_ENABLE_MIOPEN=1 \
   -e MIOPEN_FIND_MODE=3 -e MIOPEN_FIND_ENFORCE=3 \
   kokoro-tts python docker/rocm/warmup_miopen.py
 ```
 
-This sweeps every phoneme length up to 340 and takes hours (~2 on Strix Halo). Run it once per ROCm or PyTorch upgrade. Then start normally: the default `MIOPEN_FIND_MODE=2` reuses the cache. `docker compose down -v` clears it.
+This sweeps every phoneme length up to 340 and takes hours (~2 on Strix Halo). Run it once per ROCm or PyTorch upgrade. Then start with `KOKORO_ENABLE_MIOPEN=1` and the default `MIOPEN_FIND_MODE=2`, which reuses the cache. `docker compose down -v` clears it.
+
+Note the sweep covers phoneme counts, and shape is not a function of phoneme count: on gfx1100, 20 random texts of the same word count produced 20 distinct output lengths. It therefore cannot cover every shape.
 
 Generating audio for a few paragraphs of varied length under the same overrides is the cheaper, partial version.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -116,19 +116,18 @@ MIOpen compiles a kernel per unique tensor shape, which costs 5-60s a shape. Kok
 
 Because of that, MIOpen is **disabled by default on ROCm**; PyTorch's shape-independent kernels are used instead. Measured on gfx1100 / ROCm 7.2, six novel texts: 2433ms per generation with MIOpen, 268ms without. If first requests are still slow, check the startup log for `MIOpen disabled`.
 
-To go back to MIOpen, set `KOKORO_ENABLE_MIOPEN=1`. The image ships `MIOPEN_FIND_MODE=2` and prebaked kernel databases, but only for the architectures listed in `docker/rocm/kdb_install.sh` (CDNA plus gfx1030). RDNA 3 has no prebaked database, so the search runs on first use.
+To go back to MIOpen, set `ENABLE_MIOPEN=true`. The image ships `MIOPEN_FIND_MODE=2` and prebaked kernel databases, but only for the architectures listed in `docker/rocm/kdb_install.sh` (CDNA plus gfx1030). RDNA 3 has no prebaked database, so the search runs on first use.
 
 To pre-populate the on-disk cache, which `docker/rocm/docker-compose.yml` persists in named volumes:
 
 ```bash
 cd docker/rocm
 docker compose run --rm \
-  -e KOKORO_ENABLE_MIOPEN=1 \
   -e MIOPEN_FIND_MODE=3 -e MIOPEN_FIND_ENFORCE=3 \
   kokoro-tts python docker/rocm/warmup_miopen.py
 ```
 
-This sweeps every phoneme length up to 340 and takes hours (~2 on Strix Halo). Run it once per ROCm or PyTorch upgrade. Then start with `KOKORO_ENABLE_MIOPEN=1` and the default `MIOPEN_FIND_MODE=2`, which reuses the cache. `docker compose down -v` clears it.
+This sweeps every phoneme length up to 340 and takes hours (~2 on Strix Halo). Run it once per ROCm or PyTorch upgrade. Then start with `ENABLE_MIOPEN=true` and the default `MIOPEN_FIND_MODE=2`, which reuses the cache. `docker compose down -v` clears it.
 
 Note the sweep covers phoneme counts, and shape is not a function of phoneme count: on gfx1100, 20 random texts of the same word count produced 20 distinct output lengths. It therefore cannot cover every shape.
 


### PR DESCRIPTION
## Problem

MIOpen compiles a kernel per unseen tensor shape. Kokoro's decoder length is derived from predicted durations, so it changes with the input text and nearly every request compiles.

gfx1100 (RX 7900 XTX), ROCm 7.2, torch 2.9.1, 6 novel texts per run:

| | per generation | repeat of same text |
|---|---|---|
| MIOpen on | 2433 ms | 92 ms |
| MIOpen off | 268 ms | 218 ms |

That is 9x faster on new text, which is the normal case.
MIOpen only wins when the exact same text repeats and its shape is already compiled.

Profile of one 2.26s generation: `torch.instance_norm` is 1.57s over 70 calls, which dispatches to MIOpen batch-norm on ROCm.

## Fix

`torch.backends.cudnn.enabled = False` on ROCm, guarded by `torch.version.hip` so CUDA, CPU and MPS return early. `KOKORO_ENABLE_MIOPEN=1` restores the old behaviour.

## Why warmup_miopen.py does not cover this

It sweeps phoneme counts 1-340, but shape is not a function of phoneme count:
20 random texts at a fixed word count gave 20 distinct output lengths.

I also got no cross-process cache reuse. After clearing both MIOpen dirs and warming, a new process ran the same texts cold (687 ms vs 690 ms). A full FIND_MODE=3 plus FIND_ENFORCE=3 pass then a restart made no difference either.
May differ on gfx1151, where the #454 recipe came from.

## Output unchanged

Audio output is not changed.
Sample count and RMS match, and the on/off correlation (0.9941) is the same as between two MIOpen runs (0.9954).

## Changes

- `kokoro_v1.py`: disable MIOpen on ROCm, with `KOKORO_ENABLE_MIOPEN` override
- `test_kokoro_v1.py`: 3 tests, patching `torch.version.hip` so no GPU needed
- `docs/troubleshooting.md`: warmup section scoped behind `KOKORO_ENABLE_MIOPEN=1`
- `docs/configuration.md`: new variable in the env table

`pytest api/tests`: 315 passed. `ruff format` and `ruff check` clean.

## Caveat

Tested on gfx1100 only, and on a self-built ROCm 7.2 image rather than the repo's `docker/rocm` (ROCm 6.4.4).
The change is only in `kokoro_v1.py` behind the HIP check, so it does not depend on that image.
This flips a default for all AMD users based on one card, so numbers from other hardware are welcome.
Happy to make it opt-in instead.

## Note

Investigation and drafting were AI-assisted, per AGENTS.md.
The measurements are from my own hardware and I reviewed, tested and understand my change.