### PR TITLE
feat(web): add text normalization toggle to web UI settings

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -162,8 +162,8 @@
                     </div>
                 </div>
                 <div class="settings-options">
-                    <label class="setting-checkbox-label" for="normalize-toggle" title="Enable or disable automatic text normalization (numbers, dates, currency)">
-                        <input type="checkbox" id="normalize-toggle" class="setting-checkbox" checked>
+                    <label class="setting-toggle" for="normalize-toggle" title="Enable or disable automatic text normalization (numbers, dates, currency)">
+                        <input type="checkbox" id="normalize-toggle" checked>
                         <span>Normalize text</span>
                     </label>
                 </div>

--- a/web/index.html
+++ b/web/index.html
@@ -161,6 +161,12 @@
                         </select>
                     </div>
                 </div>
+                <div class="settings-options">
+                    <label class="setting-checkbox-label" for="normalize-toggle" title="Enable or disable automatic text normalization (numbers, dates, currency)">
+                        <input type="checkbox" id="normalize-toggle" class="setting-checkbox" checked>
+                        <span>Normalize text</span>
+                    </label>
+                </div>
             </section>
 
             <section class="generate-card">

--- a/web/src/services/AudioService.js
+++ b/web/src/services/AudioService.js
@@ -101,7 +101,7 @@ export class AudioService {
             this.downloadName = this.buildDownloadName(voice, responseFormat);
 
             const apiUrl = await config.getApiUrl('/v1/audio/speech');
-            const requestBody = this.buildRequestBody(text, voice, speed, options);
+            const requestBody = this.buildRequestBody(text, voice, speed, options, responseFormat);
             const response = await fetch(apiUrl, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
@@ -594,10 +594,10 @@ export class AudioService {
         return `${safeVoice || 'speech'}_${stamp}.${format}`;
     }
 
-    buildRequestBody(text, voice, speed, options = {}) {
-        const responseFormat = typeof document !== 'undefined'
+    buildRequestBody(text, voice, speed, options = {}, responseFormat = null) {
+        const format = responseFormat || options.responseFormat || (typeof document !== 'undefined'
             ? document.getElementById('format-select')?.value || 'mp3'
-            : 'mp3';
+            : 'mp3');
         const langCode = typeof document !== 'undefined'
             ? document.getElementById('lang-select')?.value || undefined
             : undefined;
@@ -608,8 +608,8 @@ export class AudioService {
         const body = {
             input: text,
             voice: voice,
-            response_format: responseFormat,
-            download_format: responseFormat,
+            response_format: format,
+            download_format: format,
             stream: true,
             speed: speed,
             return_download_link: true,

--- a/web/src/services/AudioService.js
+++ b/web/src/services/AudioService.js
@@ -101,25 +101,11 @@ export class AudioService {
             this.downloadName = this.buildDownloadName(voice, responseFormat);
 
             const apiUrl = await config.getApiUrl('/v1/audio/speech');
+            const requestBody = this.buildRequestBody(text, voice, speed, options);
             const response = await fetch(apiUrl, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({
-                    input: text,
-                    voice: voice,
-                    response_format: responseFormat,
-                    download_format: responseFormat,
-                    stream: true,
-                    speed: speed,
-                    return_download_link: true,
-                    return_timing: true,
-                    lang_code: document.getElementById('lang-select').value || undefined,
-                    allow_voice_tags: options.allowVoiceTags || undefined,
-                    // short names only mean something alongside the map that defines them
-                    voice_aliases: Object.keys(options.voiceAliases || {}).length
-                        ? options.voiceAliases
-                        : undefined
-                }),
+                body: JSON.stringify(requestBody),
                 signal: this.controller.signal
             }).catch(error => {
                 // Handle abort errors gracefully
@@ -606,6 +592,40 @@ export class AudioService {
             .replace(/[^A-Za-z0-9._-]+/g, '_')
             .replace(/^[._-]+|[._-]+$/g, '');
         return `${safeVoice || 'speech'}_${stamp}.${format}`;
+    }
+
+    buildRequestBody(text, voice, speed, options = {}) {
+        const responseFormat = typeof document !== 'undefined'
+            ? document.getElementById('format-select')?.value || 'mp3'
+            : 'mp3';
+        const langCode = typeof document !== 'undefined'
+            ? document.getElementById('lang-select')?.value || undefined
+            : undefined;
+        const normalizeToggle = typeof document !== 'undefined'
+            ? document.getElementById('normalize-toggle')
+            : null;
+
+        const body = {
+            input: text,
+            voice: voice,
+            response_format: responseFormat,
+            download_format: responseFormat,
+            stream: true,
+            speed: speed,
+            return_download_link: true,
+            return_timing: true,
+            lang_code: langCode,
+            allow_voice_tags: options.allowVoiceTags || undefined,
+            voice_aliases: Object.keys(options.voiceAliases || {}).length
+                ? options.voiceAliases
+                : undefined
+        };
+
+        if (normalizeToggle && normalizeToggle.checked === false) {
+            body.normalization_options = { normalize: false };
+        }
+
+        return body;
     }
 
     async getTimingUrl() {

--- a/web/styles/controls.css
+++ b/web/styles/controls.css
@@ -63,6 +63,32 @@
     color: var(--text);
 }
 
+.settings-options {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding-top: 0.1rem;
+}
+
+.setting-checkbox-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 0.75rem;
+    color: var(--text-light);
+    cursor: pointer;
+    user-select: none;
+}
+
+.setting-checkbox-label:hover {
+    color: var(--text);
+}
+
+.setting-checkbox {
+    accent-color: var(--fg-color);
+    cursor: pointer;
+}
+
 /* ── generate */
 .generate-card {
     display: flex;

--- a/web/styles/controls.css
+++ b/web/styles/controls.css
@@ -70,22 +70,12 @@
     padding-top: 0.1rem;
 }
 
-.setting-checkbox-label {
-    display: inline-flex;
+.setting-toggle {
+    display: flex;
     align-items: center;
     gap: 0.4rem;
-    font-size: 0.75rem;
     color: var(--text-light);
-    cursor: pointer;
-    user-select: none;
-}
-
-.setting-checkbox-label:hover {
-    color: var(--text);
-}
-
-.setting-checkbox {
-    accent-color: var(--fg-color);
+    font-size: 0.75rem;
     cursor: pointer;
 }
 

--- a/web/tests/unit/audio-service.test.mjs
+++ b/web/tests/unit/audio-service.test.mjs
@@ -57,6 +57,38 @@ test('timing download URL reuses the audio save-as name', async () => {
     assert.equal(await service.getTimingDownloadUrl(), null);
 });
 
+test('buildRequestBody leaves normalization_options undefined by default', () => {
+    const service = new AudioService();
+    const body = service.buildRequestBody('Hello world', 'af_bella', 1.0);
+
+    assert.equal(body.input, 'Hello world');
+    assert.equal(body.voice, 'af_bella');
+    assert.equal(body.speed, 1.0);
+    assert.equal(body.normalization_options, undefined);
+});
+
+test('buildRequestBody sets normalization_options.normalize to false when toggle is unchecked', () => {
+    const service = new AudioService();
+
+    // Mock document with unchecked normalize-toggle
+    const previousDocument = globalThis.document;
+    globalThis.document = {
+        getElementById(id) {
+            if (id === 'normalize-toggle') {
+                return { checked: false };
+            }
+            return null;
+        }
+    };
+
+    try {
+        const body = service.buildRequestBody('Hello world', 'af_bella', 1.0);
+        assert.deepEqual(body.normalization_options, { normalize: false });
+    } finally {
+        globalThis.document = previousDocument;
+    }
+});
+
 // Stand-in for teardown only: a real element fires an error when its src is blanked.
 class TeardownAudio {
     constructor() {

--- a/web/tests/unit/audio-service.test.mjs
+++ b/web/tests/unit/audio-service.test.mjs
@@ -89,6 +89,14 @@ test('buildRequestBody sets normalization_options.normalize to false when toggle
     }
 });
 
+test('buildRequestBody uses passed responseFormat without reading format-select DOM', () => {
+    const service = new AudioService();
+    const body = service.buildRequestBody('Hello world', 'af_bella', 1.0, {}, 'wav');
+
+    assert.equal(body.response_format, 'wav');
+    assert.equal(body.download_format, 'wav');
+});
+
 // Stand-in for teardown only: a real element fires an error when its src is blanked.
 class TeardownAudio {
     constructor() {


### PR DESCRIPTION
## Summary

Adds a 'Normalize text' checkbox toggle to the Web UI settings card, addressing #391:

- Added #normalize-toggle checkbox in web/index.html under .settings-card (checked by default).
- Added styling in web/styles/controls.css matching existing UI theme and layout.
- Updated AudioService.js to extract buildRequestBody and include normalization_options: { normalize: false } in /v1/audio/speech requests when the toggle is unchecked.
- Added unit tests in web/tests/unit/audio-service.test.mjs verifying request body construction with default vs unchecked normalization toggle.

Fixes #391

## Validation
- Ran node web/tests/unit/index.test.mjs (94/94 unit tests passing).