### PR TITLE
fix: preserve paragraph breaks as sentence boundaries in normalizer

### DIFF
--- a/api/src/services/text_processing/normalizer.py
+++ b/api/src/services/text_processing/normalizer.py
@@ -485,7 +485,13 @@ def normalize_text(text: str, normalization_options: NormalizationOptions) -> st
     text = re.sub(r"(?<=\n) +(?=\n)", "", text)
 
     # Handle special characters that might cause audio artifacts first
-    # Replace newlines with spaces (or pauses if needed)
+    # Paragraph breaks (\n\n) are converted to a period so the TTS engine
+    # treats them as sentence boundaries and produces a natural pause.
+    # Only insert a period when the preceding non-whitespace character is not
+    # already sentence-ending punctuation, avoiding double punctuation.
+    text = re.sub(r"([^\.\!\?])\n\n+", r"\1. ", text)
+    text = re.sub(r"([\.\!\?])\n\n+", r"\1 ", text)
+    # Single newlines become spaces.
     text = text.replace("\n", " ")
     text = text.replace("\r", " ")
 

--- a/api/tests/test_normalizer.py
+++ b/api/tests/test_normalizer.py
@@ -394,3 +394,59 @@ def test_re_contraction_expansion_without_apostrophe():
         )
         == "Therefore the genre was hardcore before more."
     )
+
+
+def test_paragraph_breaks_preserved_as_sentence_boundary():
+    """Paragraph breaks (\\n\\n) must become a sentence-ending period so the
+    TTS engine inserts a natural pause between sections.  Without this fix the
+    normalizer merged heading and body text into one continuous phrase."""
+    # Bare heading followed by body text
+    assert (
+        normalize_text(
+            "Steven Erikson\n\nFive riders drew rein in the pass.",
+            normalization_options=NormalizationOptions(),
+        )
+        == "Steven Erikson. Five riders drew rein in the pass."
+    )
+
+
+def test_paragraph_break_no_double_punctuation():
+    """When the paragraph already ends with sentence punctuation, no extra
+    period should be inserted."""
+    assert (
+        normalize_text(
+            "End of chapter.\n\nNew chapter begins.",
+            normalization_options=NormalizationOptions(),
+        )
+        == "End of chapter. New chapter begins."
+    )
+    assert (
+        normalize_text(
+            "Really?\n\nYes.",
+            normalization_options=NormalizationOptions(),
+        )
+        == "Really? Yes."
+    )
+
+
+def test_single_newline_becomes_space():
+    """A single newline (soft line break) is still collapsed to a space."""
+    assert (
+        normalize_text(
+            "Line one\nLine two",
+            normalization_options=NormalizationOptions(),
+        )
+        == "Line one Line two"
+    )
+
+
+def test_multiple_blank_lines_treated_as_paragraph_break():
+    """Three or more consecutive newlines should be treated like a single
+    paragraph break, not produce extra periods."""
+    assert (
+        normalize_text(
+            "Heading\n\n\nBody text.",
+            normalization_options=NormalizationOptions(),
+        )
+        == "Heading. Body text."
+    )


### PR DESCRIPTION
## Summary

- The text normalizer was replacing all newlines (including `\n\n` paragraph breaks) with spaces, causing headings and body text to be merged into one continuous phrase with no prosodic pause.
- Double-newline paragraph breaks are now converted to a period before the newline-to-space pass, giving the TTS engine a sentence boundary to pause on.
- If the character preceding the paragraph break is already sentence-ending punctuation (`.`, `!`, `?`), no extra period is inserted, avoiding double punctuation.
- Single newlines continue to become spaces as before.

**Failure case from the issue:**

```
Input:  "Steven Erikson\n\nFive riders drew rein in the pass."
Before: "Steven EriksonFive riders drew rein in the pass."  (merged, no pause)
After:  "Steven Erikson. Five riders drew rein in the pass."  (natural boundary)
```

Partial resolution of #519

## Test plan

- [x] `test_paragraph_breaks_preserved_as_sentence_boundary`: exact failure case from the issue report
- [x] `test_paragraph_break_no_double_punctuation`: paragraph already ends with `.`, `!`, or `?`
- [x] `test_single_newline_becomes_space`: soft line breaks still collapse to a space
- [x] `test_multiple_blank_lines_treated_as_paragraph_break`: three or more consecutive newlines produce exactly one period
- [x] All existing normalizer tests pass without modification