### PR TITLE
fix(normalizer): bare 'F' normalises to "farad" — duplicate 'f' key kills the fahrenheit mapping

### DIFF
--- a/api/src/services/text_processing/normalizer.py
+++ b/api/src/services/text_processing/normalizer.py
@@ -118,7 +118,6 @@ VALID_UNITS = {
     "Ω": "ohm",
     "kΩ": "kiloohm",
     "mΩ": "megaohm",  # Resistance (Ohm)
-    "f": "farad",
     "µf": "microfarad",
     "nf": "nanofarad",
     "pf": "picofarad",  # Capacitance


### PR DESCRIPTION
### The bug

`VALID_UNITS` in `api/src/services/text_processing/normalizer.py` declares the key `"f"` twice:

```python
"°c": "degree celsius",
"c":  "degree celsius",
"°f": "degree fahrenheit",
"f":  "degree fahrenheit",   # L96  — Temperature
...
"f":  "farad",               # L121 — Capacitance
```

Python keeps the last binding, so the temperature entry is discarded at import time and every bare `F` is spoken as farads:

```
"It is 72 F outside"  ->  "It is 72 farads outside"
```

The neighbouring `°c` / `c` pair shows what was intended: each temperature unit is registered both with and without the degree sign. `c` survives only because nothing later claims it; `f` does not. `°F` still normalises correctly today — only the bare form is affected, which is also the form that shows up most often in ordinary text.

`pyflakes` flags it:

```
normalizer.py:96:5:  dictionary key 'f' repeated with different values
normalizer.py:121:5: dictionary key 'f' repeated with different values
```

### The fix

Drop the capacitance entry (1 line) so bare `F` resolves to fahrenheit again.

I picked that direction because, in prose being fed to a TTS engine, a bare `F` after a number is overwhelmingly Fahrenheit, and the prefixed capacitance units `µf` / `nf` / `pf` are untouched either way. **Happy to flip it** — deleting L96 instead, or giving one of them a distinct spelling — if you'd rather keep bare `F` as farad. The important part is that right now one of the two is silently dead and it isn't obvious which.

### Verification

I AST-extracted the real `VALID_UNITS`, `UNIT_PATTERN` and `handle_units` from this file and ran `UNIT_PATTERN.sub(handle_units, ...)` with the real `inflect` engine — nothing hand-copied:

| input | before | after |
|---|---|---|
| `It is 72 F outside` | `It is 72 farads outside` | `It is 72 degrees fahrenheit outside` |
| `It is 72 °F outside` | `It is 72 degrees fahrenheit outside` | `It is 72 degrees fahrenheit outside` |
| `It is 22 C outside` | `It is 22 degrees celsius outside` | `It is 22 degrees celsius outside` |
| `a 10 F capacitor` | `a 10 farads capacitor` | `a 10 degrees fahrenheit capacitor` |

The last row is the trade-off, stated plainly. `pyflakes` reports the duplicate-key pair before the change and nothing after; no other pyflakes finding in the file changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
